### PR TITLE
Week 2 — SPL token portfolio + Mint inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,12 +14,23 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a2c365c0245cbb8959de725fc2b44c754b673fdf34c9a7f9d4a25c35a7bf1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "solana-epoch-schedule",
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
  "solana-svm-feature-set",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -388,6 +399,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +565,28 @@ checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
 dependencies = [
  "feature-probe",
  "serde",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1296,6 +1341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,11 +1522,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2492,6 +2552,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2666,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2755,6 +2841,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,6 +2917,52 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh 1.6.1",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2989,6 +3130,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -3215,6 +3362,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3678,7 +3831,7 @@ version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93b93971e289d6425f88e6e3cb6668c4b05df78b3c518c249be55ced8efd6b6d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "lazy_static",
  "solana-epoch-schedule",
  "solana-hash",
@@ -4057,7 +4210,7 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37192c0be5c222ca49dbc5667288c5a8bb14837051dd98e541ee4dad160a5da9"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bincode",
  "bv",
  "bytes",
@@ -5227,6 +5380,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sysvar",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5238,6 +5419,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "solana-sdk",
  "storm-core",
  "storm-solana",
  "tokio",
@@ -5250,7 +5432,9 @@ name = "storm-core"
 version = "0.1.0"
 dependencies = [
  "config",
+ "rust_decimal",
  "serde",
+ "solana-sdk",
  "thiserror 1.0.69",
 ]
 
@@ -5261,6 +5445,7 @@ dependencies = [
  "reqwest",
  "solana-client",
  "solana-sdk",
+ "spl-token",
  "storm-core",
 ]
 
@@ -5329,6 +5514,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -5821,6 +6012,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5887,6 +6088,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -6283,6 +6485,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x509-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ clap = { version = "4", features = ["derive"] }
 
 solana-client = "2"
 solana-sdk = "2"
+spl-token = "8"
+rust_decimal = "1"
 
 # Pulled in transitively by solana-client; we list it here only to enable
 # `rustls-tls-native-roots` so the binary trusts the OS CA bundle (corporate

--- a/bins/storm-cli/Cargo.toml
+++ b/bins/storm-cli/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 storm-core.workspace = true
 storm-solana.workspace = true
 
+solana-sdk.workspace = true
 tokio.workspace = true
 clap.workspace = true
 anyhow.workspace = true

--- a/bins/storm-cli/src/main.rs
+++ b/bins/storm-cli/src/main.rs
@@ -1,4 +1,7 @@
+use std::str::FromStr;
+
 use clap::{Parser, Subcommand};
+use solana_sdk::pubkey::Pubkey;
 use storm_core::Config;
 use storm_solana::RpcContext;
 
@@ -17,6 +20,16 @@ enum Command {
     Balance {
         /// Public key (base58)
         address: String,
+    },
+    /// List every SPL token holding for a wallet.
+    Portfolio {
+        /// Wallet public key (base58)
+        wallet: String,
+    },
+    /// Fetch and print a single SPL Mint (decimals, supply, authorities).
+    Mint {
+        /// Mint public key (base58)
+        mint: String,
     },
 }
 
@@ -43,6 +56,49 @@ async fn main() -> anyhow::Result<()> {
             println!("data bytes : {}", snap.data_len);
             println!("rent epoch : {}", snap.rent_epoch);
             println!("slot       : {}", snap.slot);
+        }
+        Command::Portfolio { wallet } => {
+            let owner = Pubkey::from_str(&wallet)
+                .map_err(|e| anyhow::anyhow!("invalid wallet pubkey '{wallet}': {e}"))?;
+            let entries = rpc.fetch_portfolio(&owner).await?;
+            if entries.is_empty() {
+                println!("(no SPL token accounts found for {owner})");
+                return Ok(());
+            }
+            println!("portfolio for {owner} — {} token account(s)", entries.len());
+            println!(
+                "{:<44}  {:<44}  {:>24}  {:>10}",
+                "TOKEN_ACCOUNT", "MINT", "AMOUNT", "DECIMALS"
+            );
+            for e in &entries {
+                println!(
+                    "{:<44}  {:<44}  {:>24}  {:>10}",
+                    e.token_account,
+                    e.holding.token.mint,
+                    e.holding.ui_amount(),
+                    e.holding.token.decimals
+                );
+            }
+        }
+        Command::Mint { mint } => {
+            let pk = Pubkey::from_str(&mint)
+                .map_err(|e| anyhow::anyhow!("invalid mint pubkey '{mint}': {e}"))?;
+            let info = rpc.fetch_mint(&pk).await?;
+            println!("address          : {}", info.address);
+            println!("decimals         : {}", info.decimals);
+            println!("supply (raw)     : {}", info.supply);
+            println!(
+                "mint authority   : {}",
+                info.mint_authority
+                    .map(|p| p.to_string())
+                    .unwrap_or_else(|| "<none>".into())
+            );
+            println!(
+                "freeze authority : {}",
+                info.freeze_authority
+                    .map(|p| p.to_string())
+                    .unwrap_or_else(|| "<none>".into())
+            );
         }
     }
 

--- a/crates/storm-core/Cargo.toml
+++ b/crates/storm-core/Cargo.toml
@@ -11,3 +11,5 @@ repository.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 config.workspace = true
+solana-sdk.workspace = true
+rust_decimal.workspace = true

--- a/crates/storm-core/src/lib.rs
+++ b/crates/storm-core/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod config;
 pub mod error;
+pub mod types;
 
 pub use config::{Config, SolanaConfig};
 pub use error::{Result, StormError};
+pub use types::{Price, Token, TokenAmount};

--- a/crates/storm-core/src/types.rs
+++ b/crates/storm-core/src/types.rs
@@ -1,0 +1,107 @@
+use std::fmt;
+
+use rust_decimal::Decimal;
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Token {
+    pub mint: Pubkey,
+    pub symbol: Option<String>,
+    pub decimals: u8,
+}
+
+impl Token {
+    pub fn new(mint: Pubkey, decimals: u8) -> Self {
+        Self {
+            mint,
+            symbol: None,
+            decimals,
+        }
+    }
+
+    pub fn with_symbol(mut self, symbol: impl Into<String>) -> Self {
+        self.symbol = Some(symbol.into());
+        self
+    }
+
+    pub fn label(&self) -> String {
+        self.symbol.clone().unwrap_or_else(|| self.mint.to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TokenAmount {
+    pub token: Token,
+    pub raw: u64,
+}
+
+impl TokenAmount {
+    pub fn new(token: Token, raw: u64) -> Self {
+        Self { token, raw }
+    }
+
+    /// Human-readable amount: `raw / 10^decimals`.
+    pub fn ui_amount(&self) -> Decimal {
+        Decimal::from_i128_with_scale(self.raw as i128, self.token.decimals as u32)
+    }
+}
+
+impl fmt::Display for TokenAmount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {}", self.ui_amount(), self.token.label())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Price {
+    pub base: Token,
+    pub quote: Token,
+    pub value: Decimal,
+}
+
+impl fmt::Display for Price {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{} {}",
+            self.base.label(),
+            self.quote.label(),
+            self.value
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn usdc() -> Token {
+        let mint = Pubkey::from_str("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").unwrap();
+        Token::new(mint, 6).with_symbol("USDC")
+    }
+
+    #[test]
+    fn ui_amount_respects_decimals() {
+        let a = TokenAmount::new(usdc(), 1_234_567);
+        assert_eq!(a.ui_amount().to_string(), "1.234567");
+    }
+
+    #[test]
+    fn ui_amount_handles_u64_max() {
+        let a = TokenAmount::new(usdc(), u64::MAX);
+        // u64::MAX = 18446744073709551615; with 6 decimals → 18446744073709.551615
+        assert_eq!(a.ui_amount().to_string(), "18446744073709.551615");
+    }
+
+    #[test]
+    fn display_falls_back_to_mint_when_no_symbol() {
+        let mint = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
+        let unknown = Token::new(mint, 9);
+        let a = TokenAmount::new(unknown, 1_500_000_000);
+        assert_eq!(
+            a.to_string(),
+            "1.500000000 So11111111111111111111111111111111111111112"
+        );
+    }
+}

--- a/crates/storm-solana/Cargo.toml
+++ b/crates/storm-solana/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 storm-core.workspace = true
 solana-client.workspace = true
 solana-sdk.workspace = true
+spl-token.workspace = true
 # Listed only to layer the `rustls-tls-native-roots` feature onto the reqwest
 # instance solana-client builds. See the comment in the workspace Cargo.toml.
 reqwest.workspace = true

--- a/crates/storm-solana/src/accounts.rs
+++ b/crates/storm-solana/src/accounts.rs
@@ -1,0 +1,182 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use solana_sdk::{program_pack::Pack, pubkey::Pubkey};
+use storm_core::{Result, StormError, Token, TokenAmount};
+
+use crate::rpc::RpcContext;
+
+#[derive(Debug, Clone)]
+pub struct MintInfo {
+    pub address: Pubkey,
+    pub decimals: u8,
+    pub supply: u64,
+    pub mint_authority: Option<Pubkey>,
+    pub freeze_authority: Option<Pubkey>,
+}
+
+impl MintInfo {
+    pub fn unpack(address: Pubkey, data: &[u8]) -> Result<Self> {
+        let m = spl_token::state::Mint::unpack(data)
+            .map_err(|e| StormError::Parse(format!("unpack mint {address}: {e}")))?;
+        Ok(Self {
+            address,
+            decimals: m.decimals,
+            supply: m.supply,
+            mint_authority: Option::<Pubkey>::from(m.mint_authority),
+            freeze_authority: Option::<Pubkey>::from(m.freeze_authority),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TokenAccountSnapshot {
+    pub address: Pubkey,
+    pub mint: Pubkey,
+    pub owner: Pubkey,
+    pub amount: u64,
+}
+
+impl TokenAccountSnapshot {
+    pub fn unpack(address: Pubkey, data: &[u8]) -> Result<Self> {
+        let a = spl_token::state::Account::unpack(data)
+            .map_err(|e| StormError::Parse(format!("unpack token account {address}: {e}")))?;
+        Ok(Self {
+            address,
+            mint: a.mint,
+            owner: a.owner,
+            amount: a.amount,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PortfolioEntry {
+    pub token_account: Pubkey,
+    pub wallet: Pubkey,
+    pub holding: TokenAmount,
+}
+
+impl RpcContext {
+    pub async fn fetch_mint(&self, address: &Pubkey) -> Result<MintInfo> {
+        let acct = self
+            .rpc()
+            .get_account_with_commitment(address, self.commitment())
+            .await
+            .map_err(|e| StormError::Rpc(e.to_string()))?
+            .value
+            .ok_or_else(|| StormError::Parse(format!("mint {address} not found")))?;
+        MintInfo::unpack(*address, &acct.data)
+    }
+
+    pub async fn fetch_portfolio(&self, owner: &Pubkey) -> Result<Vec<PortfolioEntry>> {
+        use solana_client::rpc_request::TokenAccountsFilter;
+
+        let keyed = self
+            .rpc()
+            .get_token_accounts_by_owner(owner, TokenAccountsFilter::ProgramId(spl_token::id()))
+            .await
+            .map_err(|e| StormError::Rpc(e.to_string()))?;
+
+        if keyed.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ta_addrs: Vec<Pubkey> = keyed
+            .iter()
+            .map(|k| {
+                Pubkey::from_str(&k.pubkey).map_err(|e| {
+                    StormError::Parse(format!("invalid token-account pubkey '{}': {e}", k.pubkey))
+                })
+            })
+            .collect::<Result<_>>()?;
+
+        let raw_tas = self
+            .rpc()
+            .get_multiple_accounts(&ta_addrs)
+            .await
+            .map_err(|e| StormError::Rpc(e.to_string()))?;
+
+        let mut snapshots = Vec::with_capacity(ta_addrs.len());
+        for (addr, maybe) in ta_addrs.iter().zip(raw_tas.iter()) {
+            let acct = maybe
+                .as_ref()
+                .ok_or_else(|| StormError::Parse(format!("token account {addr} vanished")))?;
+            snapshots.push(TokenAccountSnapshot::unpack(*addr, &acct.data)?);
+        }
+
+        let mut unique_mints: Vec<Pubkey> = snapshots.iter().map(|s| s.mint).collect();
+        unique_mints.sort();
+        unique_mints.dedup();
+
+        let raw_mints = self
+            .rpc()
+            .get_multiple_accounts(&unique_mints)
+            .await
+            .map_err(|e| StormError::Rpc(e.to_string()))?;
+
+        let mut decimals_by_mint: HashMap<Pubkey, u8> = HashMap::with_capacity(unique_mints.len());
+        for (addr, maybe) in unique_mints.iter().zip(raw_mints.iter()) {
+            let acct = maybe
+                .as_ref()
+                .ok_or_else(|| StormError::Parse(format!("mint {addr} not found")))?;
+            let m = MintInfo::unpack(*addr, &acct.data)?;
+            decimals_by_mint.insert(*addr, m.decimals);
+        }
+
+        let portfolio = snapshots
+            .into_iter()
+            .map(|s| {
+                let decimals = decimals_by_mint.get(&s.mint).copied().unwrap_or(0);
+                let token = Token::new(s.mint, decimals);
+                PortfolioEntry {
+                    token_account: s.address,
+                    wallet: s.owner,
+                    holding: TokenAmount::new(token, s.amount),
+                }
+            })
+            .collect();
+
+        Ok(portfolio)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // USDC mint snapshot captured live (82 bytes).
+    // Layout: COption(authority) | supply u64 LE | decimals u8 | initialized u8 |
+    // COption(freeze authority). Byte 44 is `decimals = 6`.
+    const USDC_MINT_BYTES: [u8; 82] = [
+        0x01, 0x00, 0x00, 0x00, 0x98, 0xfe, 0x86, 0xe8, 0x8d, 0x9b, 0xe2, 0xea, 0x8b, 0xc1, 0xcc,
+        0xa4, 0x87, 0x8b, 0x29, 0x88, 0xc2, 0x40, 0xf5, 0x2b, 0x84, 0x24, 0xbf, 0xb4, 0x0e, 0xd1,
+        0xa2, 0xdd, 0xcb, 0x5e, 0x19, 0x9b, 0x56, 0x33, 0xcc, 0x43, 0xce, 0xf3, 0x1f, 0x00, 0x06,
+        0x01, 0x01, 0x00, 0x00, 0x00, 0x62, 0x70, 0xaa, 0x8a, 0x59, 0xc5, 0x94, 0x05, 0xb4, 0x52,
+        0x86, 0xc8, 0x67, 0x72, 0xe6, 0xcd, 0x12, 0x6e, 0x9b, 0x8a, 0x5d, 0x3a, 0x38, 0x53, 0x6d,
+        0x37, 0xf7, 0xb4, 0x14, 0xe8, 0xb6, 0x67,
+    ];
+
+    fn usdc_mint() -> Pubkey {
+        Pubkey::from_str("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").unwrap()
+    }
+
+    #[test]
+    fn unpacks_real_usdc_mint() {
+        let info = MintInfo::unpack(usdc_mint(), &USDC_MINT_BYTES).unwrap();
+        assert_eq!(info.decimals, 6);
+        assert!(info.mint_authority.is_some());
+        assert!(info.freeze_authority.is_some());
+        // Sanity: supply is well above 1 billion units (USDC has billions in circulation).
+        assert!(info.supply > 1_000_000_000_000);
+    }
+
+    #[test]
+    fn rejects_truncated_mint() {
+        let err = MintInfo::unpack(usdc_mint(), &USDC_MINT_BYTES[..50]).unwrap_err();
+        match err {
+            StormError::Parse(msg) => assert!(msg.contains("unpack mint")),
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+}

--- a/crates/storm-solana/src/lib.rs
+++ b/crates/storm-solana/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod accounts;
 pub mod rpc;
 
+pub use accounts::{MintInfo, PortfolioEntry, TokenAccountSnapshot};
 pub use rpc::{AccountSnapshot, RpcContext};
 
 // Feature-unification anchor: see workspace Cargo.toml.

--- a/crates/storm-solana/src/rpc.rs
+++ b/crates/storm-solana/src/rpc.rs
@@ -9,6 +9,16 @@ pub struct RpcContext {
     commitment: CommitmentConfig,
 }
 
+impl RpcContext {
+    pub fn rpc(&self) -> &RpcClient {
+        &self.client
+    }
+
+    pub fn commitment(&self) -> CommitmentConfig {
+        self.commitment
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AccountSnapshot {
     pub address: Pubkey,


### PR DESCRIPTION
Week 2 of Phase 1. Closes #9. Still on the free public RPC — no paid services.

## Summary

- **`storm-core/src/types.rs`** — domain primitives reusable across crates:
  - `Token { mint, symbol, decimals }`, with `Token::new`, `with_symbol`, `label()` (falls back to mint when symbol is unknown).
  - `TokenAmount { token, raw: u64 }` — `ui_amount()` returns a `rust_decimal::Decimal` correctly scaled by `decimals` (no `f64` rounding), and `Display` prints e.g. `"408.041036 USDC"`.
  - `Price { base, quote, value: Decimal }` with `Display`.
- **`storm-solana/src/accounts.rs`**:
  - `MintInfo` and `TokenAccountSnapshot`, each with an `unpack(address, &[u8])` constructor delegating to `spl_token::state::{Mint, Account}::unpack`.
  - `RpcContext::fetch_mint(mint)` and `RpcContext::fetch_portfolio(wallet)`. Portfolio path is three RPC calls regardless of size: `getTokenAccountsByOwner` for addresses, batched `getMultipleAccounts` for raw token-account bytes, batched `getMultipleAccounts` for unique mints. No JsonParsed shortcut — the unpack code runs on every account.
  - Tiny `rpc()` / `commitment()` accessors on `RpcContext` so sibling modules don't have to live in `rpc.rs`.
- **`storm-cli`**: two new subcommands:
  - `portfolio <WALLET>` — lists every SPL holding, decimals-aware.
  - `mint <MINT>` — decimals, raw supply, mint authority, freeze authority.
- **Tests** (7 total, all green):
  - `ui_amount` rounding (including `u64::MAX`), label fallback when no symbol.
  - `MintInfo::unpack` against the actual USDC mint bytes captured live from mainnet — asserts `decimals == 6`, supply > 1T raw units, both authorities present.
  - Truncated-bytes negative case returns a `Parse` error.

## Verified live

```
$ cargo run -p storm-cli -- portfolio DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh
portfolio for DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh — 9 token account(s)
…
3qC242zWYzot287jUiNJdC8g5jFN62mrjbk8uJv4ND23  A71nSsEwW4VdE9gEzxoUvYh2gSxHAsWr6LzyM8NZpump  1.000000  6
6ULgikzdRnb8ZfFShP1LtZ6C6vkNid93omuLdC1zBddE  DmDnp799XP4bQnSrgwZCWym3VgdDhkaeovtzzFvEpump  200000.000000  6
…
```

```
$ cargo run -p storm-cli -- mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
address          : EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
decimals         : 6
supply (raw)     : 8801124500344264          ← ≈8.8B USDC outstanding
mint authority   : BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG
freeze authority : 7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` — 7/7 pass
- [x] `storm-cli portfolio` against a wallet with 9 SPL holdings prints correct decimals-adjusted amounts
- [x] `storm-cli mint` against USDC returns the right decimals/supply/authorities
- [ ] CI workflow goes green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJRvUJgvYBuDZynfvcJYxX)_