### PR TITLE
Week 4 — Orca Whirlpool + multi-DEX compare + storm-store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +394,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -833,6 +854,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +900,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +947,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1054,6 +1105,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1159,12 +1222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "ed25519"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -1198,6 +1267,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1232,6 +1304,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1332,10 +1415,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1407,6 +1507,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1567,9 +1678,29 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1593,10 +1724,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "hmac"
@@ -1626,6 +1772,15 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2026,6 +2181,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -2038,6 +2196,18 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.5",
+]
 
 [[package]]
 name = "libsecp256k1"
@@ -2088,6 +2258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2308,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2260,6 +2451,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2459,7 +2667,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2495,6 +2703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,10 +2733,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2873,6 +3117,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,6 +3260,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3444,6 +3717,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,6 +3761,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -5447,12 +5733,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -5494,6 +5799,193 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls 0.23.40",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5505,9 +5997,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "rust_decimal",
  "solana-sdk",
  "storm-core",
  "storm-solana",
+ "storm-store",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5535,6 +6029,28 @@ dependencies = [
  "solana-sdk",
  "spl-token",
  "storm-core",
+]
+
+[[package]]
+name = "storm-store"
+version = "0.1.0"
+dependencies = [
+ "rust_decimal",
+ "solana-sdk",
+ "sqlx",
+ "storm-core",
+ "tokio",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -6055,10 +6571,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-width"
@@ -6196,6 +6733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6297,11 +6840,30 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -6348,6 +6910,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6403,6 +6974,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6442,6 +7028,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6460,6 +7052,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6475,6 +7073,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6508,6 +7112,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6523,6 +7133,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6544,6 +7160,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6559,6 +7181,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/rgg81/solana-storm"
 [workspace.dependencies]
 storm-core = { path = "crates/storm-core" }
 storm-solana = { path = "crates/storm-solana" }
+storm-store = { path = "crates/storm-store" }
 
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 thiserror = "1"
@@ -28,6 +29,8 @@ spl-token = "8"
 rust_decimal = "1"
 
 proptest = "1"
+
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate"] }
 
 # Pulled in transitively by solana-client; we list it here only to enable
 # `rustls-tls-native-roots` so the binary trusts the OS CA bundle (corporate

--- a/bins/storm-cli/src/main.rs
+++ b/bins/storm-cli/src/main.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use clap::{Parser, Subcommand};
 use solana_sdk::pubkey::Pubkey;
 use storm_core::{Config, Token, TokenAmount};
-use storm_solana::{DexPool, RpcContext};
+use storm_solana::{DexPool, OrcaWhirlpool, RaydiumPool, RpcContext};
+use storm_store::{Dex, PoolRow, PriceSnapshot, Store};
 
 const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 
@@ -35,6 +36,43 @@ enum Command {
     Pool {
         /// Raydium AMM v4 pool address (base58)
         address: String,
+    },
+    /// Fetch an Orca Whirlpool (concentrated liquidity).
+    Whirlpool {
+        /// Orca Whirlpool address (base58)
+        address: String,
+    },
+    /// Compare a Raydium pool and an Orca Whirlpool for the same pair.
+    Compare {
+        /// Raydium AMM v4 pool address
+        raydium: String,
+        /// Orca Whirlpool address
+        orca: String,
+    },
+    /// Local-storage operations (SQLite).
+    Db {
+        #[command(subcommand)]
+        command: DbCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum DbCommand {
+    /// Initialise the SQLite store and run migrations.
+    Init {
+        /// SQLite URL (default: sqlite://./storm.db)
+        #[arg(long, default_value = "sqlite://./storm.db")]
+        db: String,
+    },
+    /// Snapshot the current price of a Raydium pool and an Orca Whirlpool.
+    Log {
+        /// Raydium AMM v4 pool address
+        raydium: String,
+        /// Orca Whirlpool address
+        orca: String,
+        /// SQLite URL (default: sqlite://./storm.db)
+        #[arg(long, default_value = "sqlite://./storm.db")]
+        db: String,
     },
 }
 
@@ -176,7 +214,164 @@ async fn main() -> anyhow::Result<()> {
             let out_a = pool.calculate_swap_output(&one_b)?;
             println!("swap 1 {b_sym} → {} {a_sym}", out_a.ui_amount().round_dp(9));
         }
+        Command::Whirlpool { address } => {
+            let pk = Pubkey::from_str(&address)
+                .map_err(|e| anyhow::anyhow!("invalid whirlpool pubkey '{address}': {e}"))?;
+            let pool = rpc.fetch_orca_whirlpool(&pk).await?;
+            print_whirlpool(&pool);
+        }
+        Command::Compare { raydium, orca } => {
+            let r_pk = Pubkey::from_str(&raydium)
+                .map_err(|e| anyhow::anyhow!("invalid raydium pubkey '{raydium}': {e}"))?;
+            let o_pk = Pubkey::from_str(&orca)
+                .map_err(|e| anyhow::anyhow!("invalid orca pubkey '{orca}': {e}"))?;
+            let (r, o) = tokio::try_join!(
+                rpc.fetch_raydium_pool(&r_pk),
+                rpc.fetch_orca_whirlpool(&o_pk),
+            )?;
+            print_comparison(&r, &o);
+        }
+        Command::Db { command } => match command {
+            DbCommand::Init { db } => {
+                let store = Store::open(&db).await?;
+                store.migrate().await?;
+                println!("initialised SQLite store at {db}");
+            }
+            DbCommand::Log { raydium, orca, db } => {
+                let store = Store::open(&db).await?;
+                store.migrate().await?;
+                let r_pk = Pubkey::from_str(&raydium)
+                    .map_err(|e| anyhow::anyhow!("invalid raydium pubkey '{raydium}': {e}"))?;
+                let o_pk = Pubkey::from_str(&orca)
+                    .map_err(|e| anyhow::anyhow!("invalid orca pubkey '{orca}': {e}"))?;
+                let (r, o) = tokio::try_join!(
+                    rpc.fetch_raydium_pool(&r_pk),
+                    rpc.fetch_orca_whirlpool(&o_pk),
+                )?;
+                persist_snapshot(&store, &r, Dex::RaydiumAmmV4).await?;
+                persist_snapshot(&store, &o, Dex::OrcaWhirlpool).await?;
+                println!("snapshotted prices for both pools into {db}");
+                print_comparison(&r, &o);
+            }
+        },
     }
 
+    Ok(())
+}
+
+fn print_whirlpool(pool: &OrcaWhirlpool) {
+    let (ra, rb) = pool.reserves();
+    let a_sym = known_symbol(&pool.token_a().mint).unwrap_or("A");
+    let b_sym = known_symbol(&pool.token_b().mint).unwrap_or("B");
+    println!("whirlpool      : {}", pool.pool_address());
+    println!("program        : {}", pool.program_id());
+    println!(
+        "token A        : {}  decimals={}",
+        label_for(&pool.token_a().mint),
+        pool.token_a().decimals
+    );
+    println!(
+        "token B        : {}  decimals={}",
+        label_for(&pool.token_b().mint),
+        pool.token_b().decimals
+    );
+    println!(
+        "vault A        : {} {a_sym}  (all-tick total)",
+        ra.ui_amount()
+    );
+    println!(
+        "vault B        : {} {b_sym}  (all-tick total)",
+        rb.ui_amount()
+    );
+    let bps = (pool.state.fee_rate as u64) * 10_000 / 1_000_000;
+    println!(
+        "fee_rate       : {} hundredths-of-bp  (~{} bps)",
+        pool.state.fee_rate, bps
+    );
+    println!("tick_spacing   : {}", pool.state.tick_spacing);
+    println!("liquidity (L)  : {}", pool.state.liquidity);
+    println!("sqrt_price_x64 : {}", pool.state.sqrt_price_x64);
+    println!("tick_current   : {}", pool.state.tick_current_index);
+    println!(
+        "spot price     : {} {b_sym} per {a_sym}",
+        pool.price().round_dp(6)
+    );
+    let one_a = TokenAmount::new(
+        Token::new(pool.token_a().mint, pool.token_a().decimals),
+        10u64.pow(pool.token_a().decimals as u32),
+    );
+    if let Ok(out) = pool.calculate_swap_output(&one_a) {
+        println!(
+            "swap 1 {a_sym} → ~{} {b_sym}  (CPMM approx around active range)",
+            out.ui_amount().round_dp(6)
+        );
+    }
+}
+
+fn print_comparison(r: &RaydiumPool, o: &OrcaWhirlpool) {
+    if r.token_a().mint != o.token_a().mint || r.token_b().mint != o.token_b().mint {
+        println!(
+            "warning: token pairs differ — Raydium ({}/{}) vs Orca ({}/{})",
+            label_for(&r.token_a().mint),
+            label_for(&r.token_b().mint),
+            label_for(&o.token_a().mint),
+            label_for(&o.token_b().mint),
+        );
+    }
+    let a_sym = known_symbol(&r.token_a().mint).unwrap_or("A");
+    let b_sym = known_symbol(&r.token_b().mint).unwrap_or("B");
+    let pr = r.price();
+    let po = o.price();
+    println!("pair           : {}/{}", a_sym, b_sym);
+    println!(
+        "Raydium ({}) : {} {b_sym} per {a_sym}",
+        r.pool_address(),
+        pr.round_dp(6)
+    );
+    println!(
+        "Orca    ({}) : {} {b_sym} per {a_sym}",
+        o.pool_address(),
+        po.round_dp(6)
+    );
+    if pr.is_zero() || po.is_zero() {
+        println!("(one of the prices is zero — can't compute spread)");
+        return;
+    }
+    let spread = pr - po;
+    let spread_bps = (spread / po) * rust_decimal::Decimal::from(10_000);
+    let direction = if spread > rust_decimal::Decimal::ZERO {
+        format!("buy {a_sym} on Orca, sell on Raydium")
+    } else if spread < rust_decimal::Decimal::ZERO {
+        format!("buy {a_sym} on Raydium, sell on Orca")
+    } else {
+        "no spread".to_string()
+    };
+    println!(
+        "spread         : {} {b_sym}  ({} bps)",
+        spread.round_dp(6),
+        spread_bps.round_dp(2)
+    );
+    println!("direction      : {direction}");
+}
+
+async fn persist_snapshot<P: DexPool>(store: &Store, pool: &P, dex: Dex) -> anyhow::Result<()> {
+    let row = PoolRow {
+        address: *pool.pool_address(),
+        program_id: *pool.program_id(),
+        dex,
+        token_a_mint: pool.token_a().mint,
+        token_b_mint: pool.token_b().mint,
+        token_a_decimals: pool.token_a().decimals,
+        token_b_decimals: pool.token_b().decimals,
+    };
+    store.upsert_pool(&row).await?;
+    let (ra, rb) = pool.reserves();
+    let snap = PriceSnapshot {
+        pool_address: *pool.pool_address(),
+        spot_price: pool.price(),
+        reserve_a_raw: ra.raw,
+        reserve_b_raw: rb.raw,
+    };
+    store.insert_price_snapshot(&snap).await?;
     Ok(())
 }

--- a/crates/storm-solana/src/lib.rs
+++ b/crates/storm-solana/src/lib.rs
@@ -3,7 +3,10 @@ pub mod pools;
 pub mod rpc;
 
 pub use accounts::{MintInfo, PortfolioEntry, TokenAccountSnapshot};
-pub use pools::{DexPool, RaydiumPool, RaydiumPoolState, RAYDIUM_AMM_V4_PROGRAM_ID};
+pub use pools::{
+    sqrt_price_x64_to_price, DexPool, OrcaWhirlpool, RaydiumPool, RaydiumPoolState, WhirlpoolState,
+    ORCA_WHIRLPOOL_PROGRAM_ID, RAYDIUM_AMM_V4_PROGRAM_ID,
+};
 pub use rpc::{AccountSnapshot, RpcContext};
 
 // Feature-unification anchor: see workspace Cargo.toml.

--- a/crates/storm-solana/src/pools.rs
+++ b/crates/storm-solana/src/pools.rs
@@ -221,6 +221,272 @@ impl RpcContext {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Orca Whirlpool (concentrated liquidity, Anchor account layout)
+// ---------------------------------------------------------------------------
+
+pub const ORCA_WHIRLPOOL_PROGRAM_ID: Pubkey =
+    solana_sdk::pubkey!("whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc");
+
+/// Anchor 8-byte discriminator for the `Whirlpool` account type.
+/// `sha256("account:Whirlpool")[..8]` (little-endian as stored on-chain).
+const WHIRLPOOL_DISCRIMINATOR: [u8; 8] = [63, 149, 209, 12, 225, 128, 99, 9];
+
+/// `2^64` as a `Decimal`. Used to convert `sqrt_price_x64` (Q64.64
+/// fixed-point) into a regular fraction.
+fn two_pow_64() -> Decimal {
+    // 18_446_744_073_709_551_616 fits in `i128` (well under `i128::MAX`).
+    Decimal::from_i128_with_scale(1 << 32, 0) * Decimal::from_i128_with_scale(1 << 32, 0)
+}
+
+/// Convert `sqrt_price_x64` and the two side decimals into a
+/// decimals-normalised spot price of A in terms of B.
+///
+/// `raw_price = sqrt_price_x64² / 2^128`
+/// `ui_price  = raw_price × 10^(decimals_a - decimals_b)`
+pub fn sqrt_price_x64_to_price(sqrt_price_x64: u128, decimals_a: u8, decimals_b: u8) -> Decimal {
+    // sqrt_price_x64 fits in i128 for every legal Whirlpool value
+    // (MAX_SQRT_PRICE_X64 ≈ 7.9e28, i128::MAX ≈ 1.7e38).
+    let sp = Decimal::from_i128_with_scale(sqrt_price_x64 as i128, 0) / two_pow_64();
+    let raw = sp * sp;
+    let exp = decimals_a as i32 - decimals_b as i32;
+    if exp >= 0 {
+        raw * Decimal::from(10u64.pow(exp as u32))
+    } else {
+        raw / Decimal::from(10u64.pow((-exp) as u32))
+    }
+}
+
+/// Fixed-offset view into Orca's `Whirlpool` account (653 bytes
+/// including the 8-byte Anchor discriminator). Only the fields we need
+/// are extracted. Reward arrays at the tail are skipped.
+#[derive(Debug, Clone)]
+pub struct WhirlpoolState {
+    pub tick_spacing: u16,
+    /// Fee rate in hundredths of a basis point (10 000 = 1 %).
+    pub fee_rate: u16,
+    pub liquidity: u128,
+    pub sqrt_price_x64: u128,
+    pub tick_current_index: i32,
+    pub token_mint_a: Pubkey,
+    pub token_vault_a: Pubkey,
+    pub token_mint_b: Pubkey,
+    pub token_vault_b: Pubkey,
+}
+
+impl WhirlpoolState {
+    pub const SIZE: usize = 653;
+    pub const DISCRIMINATOR: [u8; 8] = WHIRLPOOL_DISCRIMINATOR;
+
+    pub fn unpack(data: &[u8]) -> Result<Self> {
+        if data.len() != Self::SIZE {
+            return Err(StormError::Parse(format!(
+                "orca whirlpool: expected {} bytes, got {}",
+                Self::SIZE,
+                data.len()
+            )));
+        }
+        if data[..8] != Self::DISCRIMINATOR {
+            return Err(StormError::Parse(format!(
+                "orca whirlpool: wrong account discriminator (got {:?})",
+                &data[..8]
+            )));
+        }
+        Ok(Self {
+            tick_spacing: u16::from_le_bytes(data[41..43].try_into().unwrap()),
+            fee_rate: u16::from_le_bytes(data[45..47].try_into().unwrap()),
+            liquidity: u128::from_le_bytes(data[49..65].try_into().unwrap()),
+            sqrt_price_x64: u128::from_le_bytes(data[65..81].try_into().unwrap()),
+            tick_current_index: i32::from_le_bytes(data[81..85].try_into().unwrap()),
+            token_mint_a: read_pubkey(data, 101),
+            token_vault_a: read_pubkey(data, 133),
+            token_mint_b: read_pubkey(data, 181),
+            token_vault_b: read_pubkey(data, 213),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OrcaWhirlpool {
+    pub address: Pubkey,
+    pub program_id: Pubkey,
+    pub state: WhirlpoolState,
+    /// Each side's mint info, used for decimals.
+    token_a: Token,
+    token_b: Token,
+    /// Total amount sitting in the protocol vaults — across *all* tick
+    /// ranges, not just the active one. Useful for display and for
+    /// upper-bound reasoning about possible swap size.
+    vault_a_amount: u64,
+    vault_b_amount: u64,
+}
+
+impl OrcaWhirlpool {
+    pub fn new(
+        address: Pubkey,
+        program_id: Pubkey,
+        state: WhirlpoolState,
+        decimals_a: u8,
+        decimals_b: u8,
+        vault_a_amount: u64,
+        vault_b_amount: u64,
+    ) -> Self {
+        let token_a = Token::new(state.token_mint_a, decimals_a);
+        let token_b = Token::new(state.token_mint_b, decimals_b);
+        Self {
+            address,
+            program_id,
+            state,
+            token_a,
+            token_b,
+            vault_a_amount,
+            vault_b_amount,
+        }
+    }
+
+    pub fn vault_a_amount(&self) -> u64 {
+        self.vault_a_amount
+    }
+    pub fn vault_b_amount(&self) -> u64 {
+        self.vault_b_amount
+    }
+
+    /// Effective in-tick reserves derived from `(L, sqrt_price)`. Inside
+    /// a single tick range a CLMM behaves like a CPMM with these
+    /// notional reserves, so this is what to use for sample-swap math.
+    fn active_range_reserves(&self) -> (u64, u64) {
+        let l = Decimal::from_i128_with_scale(self.state.liquidity as i128, 0);
+        let sp = Decimal::from_i128_with_scale(self.state.sqrt_price_x64 as i128, 0) / two_pow_64();
+        if sp.is_zero() {
+            return (0, 0);
+        }
+        let r_a = (l / sp).floor();
+        let r_b = (l * sp).floor();
+        let cap = Decimal::from(u64::MAX);
+        let r_a = if r_a > cap { cap } else { r_a };
+        let r_b = if r_b > cap { cap } else { r_b };
+        // Decimal -> u64 via i128 (safe: we capped above).
+        use rust_decimal::prelude::ToPrimitive;
+        (r_a.to_u64().unwrap_or(0), r_b.to_u64().unwrap_or(0))
+    }
+}
+
+impl DexPool for OrcaWhirlpool {
+    fn pool_address(&self) -> &Pubkey {
+        &self.address
+    }
+    fn program_id(&self) -> &Pubkey {
+        &self.program_id
+    }
+    fn token_a(&self) -> &Token {
+        &self.token_a
+    }
+    fn token_b(&self) -> &Token {
+        &self.token_b
+    }
+    fn reserves(&self) -> (TokenAmount, TokenAmount) {
+        // Vault totals — the *full* protocol holdings, including
+        // out-of-range liquidity. For "what's in this pool right now"
+        // this is the meaningful number; for swap math we use the
+        // effective in-range reserves derived from sqrt_price + L.
+        (
+            TokenAmount::new(self.token_a.clone(), self.vault_a_amount),
+            TokenAmount::new(self.token_b.clone(), self.vault_b_amount),
+        )
+    }
+    fn price(&self) -> Decimal {
+        sqrt_price_x64_to_price(
+            self.state.sqrt_price_x64,
+            self.token_a.decimals,
+            self.token_b.decimals,
+        )
+    }
+    fn calculate_swap_output(&self, input: &TokenAmount) -> Result<TokenAmount> {
+        // CPMM approximation around the active tick range. Accurate for
+        // swaps that don't cross ticks; off by an unbounded amount once
+        // they do (caveat documented in `OrcaWhirlpool::active_range_reserves`).
+        let (eff_a, eff_b) = self.active_range_reserves();
+        let (r_in, r_out, out_token) = if input.token.mint == self.token_a.mint {
+            (eff_a, eff_b, &self.token_b)
+        } else if input.token.mint == self.token_b.mint {
+            (eff_b, eff_a, &self.token_a)
+        } else {
+            return Err(StormError::Parse(format!(
+                "input mint {} not in whirlpool {}",
+                input.token.mint, self.address
+            )));
+        };
+        // fee_rate is in hundredths-of-a-basis-point; denominator is 1_000_000.
+        let out = cpmm_swap_output(
+            r_in,
+            r_out,
+            input.raw,
+            self.state.fee_rate as u64,
+            1_000_000,
+        )
+        .ok_or_else(|| {
+            StormError::Parse(format!("whirlpool swap math overflow on {}", self.address))
+        })?;
+        Ok(TokenAmount::new(out_token.clone(), out))
+    }
+}
+
+impl RpcContext {
+    /// Fetch an Orca Whirlpool: pool state + both vaults + both mints
+    /// (for decimals) in 2 RPC calls.
+    pub async fn fetch_orca_whirlpool(&self, address: &Pubkey) -> Result<OrcaWhirlpool> {
+        let pool_account = self
+            .rpc()
+            .get_account_with_commitment(address, self.commitment())
+            .await
+            .map_err(|e| StormError::Rpc(e.to_string()))?
+            .value
+            .ok_or_else(|| StormError::Parse(format!("whirlpool {address} not found")))?;
+        if pool_account.owner != ORCA_WHIRLPOOL_PROGRAM_ID {
+            return Err(StormError::Parse(format!(
+                "account {address} is not owned by Orca Whirlpool (owner: {})",
+                pool_account.owner
+            )));
+        }
+        let state = WhirlpoolState::unpack(&pool_account.data)?;
+        let extras = self
+            .rpc()
+            .get_multiple_accounts(&[
+                state.token_vault_a,
+                state.token_vault_b,
+                state.token_mint_a,
+                state.token_mint_b,
+            ])
+            .await
+            .map_err(|e| StormError::Rpc(e.to_string()))?;
+        let vault_a = extras[0].as_ref().ok_or_else(|| {
+            StormError::Parse(format!("vault A {} vanished", state.token_vault_a))
+        })?;
+        let vault_b = extras[1].as_ref().ok_or_else(|| {
+            StormError::Parse(format!("vault B {} vanished", state.token_vault_b))
+        })?;
+        let mint_a_acct = extras[2]
+            .as_ref()
+            .ok_or_else(|| StormError::Parse(format!("mint A {} not found", state.token_mint_a)))?;
+        let mint_b_acct = extras[3]
+            .as_ref()
+            .ok_or_else(|| StormError::Parse(format!("mint B {} not found", state.token_mint_b)))?;
+        let va = TokenAccountSnapshot::unpack(state.token_vault_a, &vault_a.data)?;
+        let vb = TokenAccountSnapshot::unpack(state.token_vault_b, &vault_b.data)?;
+        let ma = crate::accounts::MintInfo::unpack(state.token_mint_a, &mint_a_acct.data)?;
+        let mb = crate::accounts::MintInfo::unpack(state.token_mint_b, &mint_b_acct.data)?;
+        Ok(OrcaWhirlpool::new(
+            *address,
+            pool_account.owner,
+            state,
+            ma.decimals,
+            mb.decimals,
+            va.amount,
+            vb.amount,
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -336,5 +602,121 @@ mod tests {
         );
         // Vault held 10 SOL but 1 SOL is PnL → reserve is 9 SOL.
         assert_eq!(pool.base_reserve_raw(), 9_000_000_000);
+    }
+
+    // ---- Orca Whirlpool ------------------------------------------------
+
+    fn synth_whirlpool_bytes(
+        sqrt_price_x64: u128,
+        liquidity: u128,
+        fee_rate: u16,
+        tick_spacing: u16,
+        tick_current_index: i32,
+        mint_a: &Pubkey,
+        mint_b: &Pubkey,
+    ) -> [u8; 653] {
+        let mut data = [0u8; 653];
+        data[..8].copy_from_slice(&WhirlpoolState::DISCRIMINATOR);
+        data[41..43].copy_from_slice(&tick_spacing.to_le_bytes());
+        data[45..47].copy_from_slice(&fee_rate.to_le_bytes());
+        data[49..65].copy_from_slice(&liquidity.to_le_bytes());
+        data[65..81].copy_from_slice(&sqrt_price_x64.to_le_bytes());
+        data[81..85].copy_from_slice(&tick_current_index.to_le_bytes());
+        data[101..133].copy_from_slice(mint_a.as_ref());
+        data[181..213].copy_from_slice(mint_b.as_ref());
+        data
+    }
+
+    #[test]
+    fn whirlpool_layout_size_is_653() {
+        assert_eq!(WhirlpoolState::SIZE, 653);
+    }
+
+    #[test]
+    fn whirlpool_unpack_rejects_wrong_discriminator() {
+        let mut data = [0u8; 653];
+        // discriminator left as zeros
+        match WhirlpoolState::unpack(&data) {
+            Err(StormError::Parse(m)) => assert!(m.contains("discriminator")),
+            other => panic!("expected discriminator error, got {other:?}"),
+        }
+        // now correct bytes
+        data[..8].copy_from_slice(&WhirlpoolState::DISCRIMINATOR);
+        // still zeros for the rest is structurally legal — verifies the path
+        WhirlpoolState::unpack(&data).unwrap();
+    }
+
+    #[test]
+    fn sqrt_price_round_trip_for_unit_price() {
+        // sqrt(1) * 2^64 = 2^64 → price = 1, no decimals difference.
+        let p = sqrt_price_x64_to_price(1u128 << 64, 6, 6);
+        assert_eq!(p.normalize().to_string(), "1");
+    }
+
+    #[test]
+    fn sqrt_price_handles_decimals_skew() {
+        // SOL/USDC at 100 USDC per SOL.
+        // raw_price = (USDC_raw / SOL_raw) at 100 ui USDC per 1 ui SOL
+        //           = 100 * 10^6 / 10^9 = 10^-1
+        // sqrt(raw_price) = 10^-0.5 ≈ 0.31622776601683794
+        // sqrt_price_x64 = 0.31622... * 2^64
+        let sqrt = 0.31622776601683794_f64;
+        let sqrt_price_x64 = (sqrt * (1u128 << 64) as f64) as u128;
+        let p = sqrt_price_x64_to_price(sqrt_price_x64, 9, 6);
+        // Allow a tiny tolerance — f64 → u128 → Decimal round-trip drift.
+        let val = p.to_string().parse::<f64>().unwrap();
+        assert!((val - 100.0).abs() < 0.01, "got {val}");
+    }
+
+    #[test]
+    fn whirlpool_price_matches_sqrt_price_helper() {
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let sqrt = 0.31622776601683794_f64;
+        let sqrt_price_x64 = (sqrt * (1u128 << 64) as f64) as u128;
+        let liquidity = 10_000_000_000_000u128;
+        let data = synth_whirlpool_bytes(
+            sqrt_price_x64,
+            liquidity,
+            5, // 0.005% fee tier (5 = 0.0005% in hundredths-bp; treat as low)
+            8,
+            0,
+            &mint_a,
+            &mint_b,
+        );
+        let state = WhirlpoolState::unpack(&data).unwrap();
+        let pool = OrcaWhirlpool::new(
+            Pubkey::new_unique(),
+            ORCA_WHIRLPOOL_PROGRAM_ID,
+            state,
+            9, // SOL
+            6, // USDC
+            0,
+            0,
+        );
+        let val = pool.price().to_string().parse::<f64>().unwrap();
+        assert!((val - 100.0).abs() < 0.01, "got {val}");
+    }
+
+    #[test]
+    fn whirlpool_swap_rejects_foreign_mint() {
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let data = synth_whirlpool_bytes(1u128 << 64, 1_000_000, 30, 8, 0, &mint_a, &mint_b);
+        let state = WhirlpoolState::unpack(&data).unwrap();
+        let pool = OrcaWhirlpool::new(
+            Pubkey::new_unique(),
+            ORCA_WHIRLPOOL_PROGRAM_ID,
+            state,
+            6,
+            6,
+            0,
+            0,
+        );
+        let foreign = TokenAmount::new(Token::new(Pubkey::new_unique(), 6), 1);
+        assert!(matches!(
+            pool.calculate_swap_output(&foreign),
+            Err(StormError::Parse(_))
+        ));
     }
 }

--- a/crates/storm-store/Cargo.toml
+++ b/crates/storm-store/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "storm-cli"
+name = "storm-store"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
@@ -9,13 +9,10 @@ repository.workspace = true
 
 [dependencies]
 storm-core.workspace = true
-storm-solana.workspace = true
-storm-store.workspace = true
-
+sqlx.workspace = true
+tokio.workspace = true
 rust_decimal.workspace = true
 solana-sdk.workspace = true
-tokio.workspace = true
-clap.workspace = true
-anyhow.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/storm-store/migrations/0001_initial.sql
+++ b/crates/storm-store/migrations/0001_initial.sql
@@ -1,0 +1,24 @@
+-- pools: one row per discovered DEX pool
+CREATE TABLE IF NOT EXISTS pools (
+    address           TEXT PRIMARY KEY,
+    program_id        TEXT NOT NULL,
+    dex               TEXT NOT NULL,            -- 'raydium-amm-v4' | 'orca-whirlpool' | …
+    token_a_mint      TEXT NOT NULL,
+    token_b_mint      TEXT NOT NULL,
+    token_a_decimals  INTEGER NOT NULL,
+    token_b_decimals  INTEGER NOT NULL,
+    discovered_at     INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- prices: append-only price snapshots, foreign-keyed to pools.
+CREATE TABLE IF NOT EXISTS prices (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    pool_address    TEXT NOT NULL REFERENCES pools(address),
+    spot_price      TEXT NOT NULL,    -- Decimal stringified for portability
+    reserve_a_raw   TEXT NOT NULL,    -- u64 stringified (sqlite max integer is i64)
+    reserve_b_raw   TEXT NOT NULL,
+    captured_at     INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS prices_pool_captured_at
+    ON prices(pool_address, captured_at DESC);

--- a/crates/storm-store/src/lib.rs
+++ b/crates/storm-store/src/lib.rs
@@ -1,0 +1,190 @@
+use rust_decimal::Decimal;
+use solana_sdk::pubkey::Pubkey;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::SqlitePool;
+use std::str::FromStr;
+use storm_core::{Result, StormError};
+
+#[derive(Clone)]
+pub struct Store {
+    pool: SqlitePool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Dex {
+    RaydiumAmmV4,
+    OrcaWhirlpool,
+}
+
+impl Dex {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Dex::RaydiumAmmV4 => "raydium-amm-v4",
+            Dex::OrcaWhirlpool => "orca-whirlpool",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PoolRow {
+    pub address: Pubkey,
+    pub program_id: Pubkey,
+    pub dex: Dex,
+    pub token_a_mint: Pubkey,
+    pub token_b_mint: Pubkey,
+    pub token_a_decimals: u8,
+    pub token_b_decimals: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct PriceSnapshot {
+    pub pool_address: Pubkey,
+    pub spot_price: Decimal,
+    pub reserve_a_raw: u64,
+    pub reserve_b_raw: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct LatestPrice {
+    pub spot_price: Decimal,
+    pub reserve_a_raw: u64,
+    pub reserve_b_raw: u64,
+    pub captured_at: i64,
+}
+
+impl Store {
+    /// Open (creating if necessary) a SQLite store at `database_url`.
+    /// `database_url` examples: `sqlite::memory:`, `sqlite://./storm.db`,
+    /// `sqlite:///abs/path/storm.db`.
+    pub async fn open(database_url: &str) -> Result<Self> {
+        let opts = SqliteConnectOptions::from_str(database_url)
+            .map_err(|e| StormError::Parse(format!("invalid sqlite url '{database_url}': {e}")))?
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect_with(opts)
+            .await
+            .map_err(|e| StormError::Rpc(format!("sqlite connect: {e}")))?;
+        Ok(Self { pool })
+    }
+
+    pub async fn migrate(&self) -> Result<()> {
+        sqlx::migrate!("./migrations")
+            .run(&self.pool)
+            .await
+            .map_err(|e| StormError::Rpc(format!("sqlite migrate: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn upsert_pool(&self, row: &PoolRow) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO pools \
+             (address, program_id, dex, token_a_mint, token_b_mint, token_a_decimals, token_b_decimals) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+             ON CONFLICT(address) DO UPDATE SET \
+                 program_id       = excluded.program_id, \
+                 dex              = excluded.dex, \
+                 token_a_mint     = excluded.token_a_mint, \
+                 token_b_mint     = excluded.token_b_mint, \
+                 token_a_decimals = excluded.token_a_decimals, \
+                 token_b_decimals = excluded.token_b_decimals",
+        )
+        .bind(row.address.to_string())
+        .bind(row.program_id.to_string())
+        .bind(row.dex.as_str())
+        .bind(row.token_a_mint.to_string())
+        .bind(row.token_b_mint.to_string())
+        .bind(row.token_a_decimals as i64)
+        .bind(row.token_b_decimals as i64)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StormError::Rpc(format!("upsert pool: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn insert_price_snapshot(&self, snap: &PriceSnapshot) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO prices (pool_address, spot_price, reserve_a_raw, reserve_b_raw) \
+             VALUES (?1, ?2, ?3, ?4)",
+        )
+        .bind(snap.pool_address.to_string())
+        .bind(snap.spot_price.to_string())
+        .bind(snap.reserve_a_raw.to_string())
+        .bind(snap.reserve_b_raw.to_string())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StormError::Rpc(format!("insert price snapshot: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn latest_price(&self, pool_address: &Pubkey) -> Result<Option<LatestPrice>> {
+        let row: Option<(String, String, String, i64)> = sqlx::query_as(
+            "SELECT spot_price, reserve_a_raw, reserve_b_raw, captured_at \
+             FROM prices WHERE pool_address = ?1 \
+             ORDER BY captured_at DESC, id DESC LIMIT 1",
+        )
+        .bind(pool_address.to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StormError::Rpc(format!("latest_price: {e}")))?;
+        Ok(row.map(|(price, ra, rb, ts)| LatestPrice {
+            spot_price: price.parse().unwrap_or(Decimal::ZERO),
+            reserve_a_raw: ra.parse().unwrap_or(0),
+            reserve_b_raw: rb.parse().unwrap_or(0),
+            captured_at: ts,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn migrate_then_roundtrip_a_snapshot() {
+        let store = Store::open("sqlite::memory:").await.unwrap();
+        store.migrate().await.unwrap();
+
+        let pool_addr = Pubkey::new_unique();
+        let row = PoolRow {
+            address: pool_addr,
+            program_id: Pubkey::new_unique(),
+            dex: Dex::RaydiumAmmV4,
+            token_a_mint: Pubkey::new_unique(),
+            token_b_mint: Pubkey::new_unique(),
+            token_a_decimals: 9,
+            token_b_decimals: 6,
+        };
+        store.upsert_pool(&row).await.unwrap();
+
+        let snap = PriceSnapshot {
+            pool_address: pool_addr,
+            spot_price: Decimal::from_str("142.5").unwrap(),
+            reserve_a_raw: 1_000_000_000_000,
+            reserve_b_raw: 142_000_000_000,
+        };
+        store.insert_price_snapshot(&snap).await.unwrap();
+        store.insert_price_snapshot(&snap).await.unwrap();
+
+        let latest = store.latest_price(&pool_addr).await.unwrap().unwrap();
+        assert_eq!(latest.spot_price.to_string(), "142.5");
+        assert_eq!(latest.reserve_a_raw, 1_000_000_000_000);
+        assert_eq!(latest.reserve_b_raw, 142_000_000_000);
+
+        // Upsert idempotency: re-upsert with different decimals should overwrite.
+        let mut updated = row;
+        updated.token_a_decimals = 8;
+        store.upsert_pool(&updated).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn latest_price_for_unknown_pool_is_none() {
+        let store = Store::open("sqlite::memory:").await.unwrap();
+        store.migrate().await.unwrap();
+        assert!(store
+            .latest_price(&Pubkey::new_unique())
+            .await
+            .unwrap()
+            .is_none());
+    }
+}


### PR DESCRIPTION
Closes #11. Final week of Phase 1. Free public RPC; no paid services.

## Summary

- **Orca Whirlpool**: full read-side support added to `crates/storm-solana/src/pools.rs`.
  - 653-byte fixed-offset parser with Anchor 8-byte discriminator verification.
  - `sqrt_price_x64_to_price()`: Q64.64 → `Decimal`, decimals-normalised — exact spot price from `sqrt_price_x64²`.
  - `DexPool::price()` uses sqrt_price (exact). `DexPool::calculate_swap_output()` uses an effective-reserve CPMM approximation around the active range — exact for swaps that don't cross ticks; documented caveat for larger swaps.
  - `RpcContext::fetch_orca_whirlpool` is **2 RPC calls** (pool + 4-account batched `getMultipleAccounts` for vaults + mints).
- **`storm-store` crate (new)**: sqlx + sqlite, runtime-checked queries. Schema (`pools` upsert + `prices` append-only) embedded as a migration. `Store::open()` / `migrate()` / `upsert_pool()` / `insert_price_snapshot()` / `latest_price()`. SQLite per scope decision (local-friendly, runs anywhere); schema is portable enough to migrate to Postgres when the bot moves to a VPS.
- **`storm-cli` — 4 new subcommands**:
  - `whirlpool <ADDR>` — vault totals, fee_rate (hundredths-of-bp), tick_spacing, raw `L` and `sqrt_price_x64`, spot, sample swap.
  - `compare <RAYDIUM> <ORCA>` — prices side-by-side, spread in bps, which side to buy / sell.
  - `db init [--db URL]` — opens SQLite, runs migrations.
  - `db log <RAYDIUM> <ORCA> [--db URL]` — fetches both pools live, upserts pool rows, appends a snapshot, prints the comparison.

  Also introduces `persist_snapshot<P: DexPool>(...)` — first generic use of the trait, future-proof for Meteora / Phoenix.

## Tests — 32/32 green

- `storm-core`: 15 (config, types, math unit + 4 proptest invariants)
- `storm-solana`: 15 — added 5 Whirlpool tests
  - `whirlpool_layout_size_is_653`
  - `whirlpool_unpack_rejects_wrong_discriminator`
  - `sqrt_price_round_trip_for_unit_price`
  - `sqrt_price_handles_decimals_skew` (SOL/USDC at 100 USDC/SOL with 9/6 decimals)
  - `whirlpool_price_matches_sqrt_price_helper`
  - `whirlpool_swap_rejects_foreign_mint`
- `storm-store`: 2 — sqlite::memory: full roundtrip (migrate → upsert pool → insert snapshot → latest_price) + missing-pool case.

## Verified live

```
$ cargo run -p storm-cli -- compare 58oQCh…YQo2  HJPjoWU…ngndJ
pair           : SOL/USDC
Raydium (58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2) : 95.234878 USDC per SOL
Orca    (HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ) : 95.198949 USDC per SOL
spread         : 0.035929 USDC  (3.77 bps)
direction      : buy SOL on Orca, sell on Raydium

$ cargo run -p storm-cli -- db log 58oQCh…YQo2 HJPjoWU…ngndJ --db sqlite://./storm.db
snapshotted prices for both pools into sqlite://./storm.db
…(prints the same comparison block)…

$ python3 -c "import sqlite3; …"
('58oQChx4…', 'raydium-amm-v4',  9, 6)
('HJPjoWU…',  'orca-whirlpool',  9, 6)
('58oQChx4…', '95.23487819…', 1778500438)
('HJPjoWU…',  '95.19894890…', 1778500438)
```

3.77 bps spread is below the round-trip cost (Raydium 25 bps + Orca 30 bps = 55 bps, before priority fees) — so not a profitable arb today, but the code correctly identifies the **direction**, which is the deliverable. Real arb opportunities will pop up during volatility (Phase 2).

## Honest scope notes

- **Whirlpool swap math**: the active-range CPMM approximation is exact only inside one tick. Crossing ticks requires fetching the corresponding `TickArray` accounts and stepping through. We'll add full CLMM swap math when MEV execution actually needs it (Phase 4 / Week 13+); for now the spot price is exact and that's what drives detection.
- **storm-store is SQLite**, not Postgres. Issue #7 will still provision Postgres on the VPS; we'll switch backends then. Schema is portable.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` — 32/32
- [x] Live `whirlpool`, `compare`, `db log` against Raydium SOL/USDC v4 + Orca SOL/USDC Whirlpool
- [x] SQLite contents verified via Python (2 pools, 4 price snapshots from 2 runs)
- [ ] CI workflow goes green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJRvUJgvYBuDZynfvcJYxX)_