### PR TITLE
Week 5 — Binance WebSocket feed + storm-monitor daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +780,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmov"
@@ -1228,6 +1259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ed25519"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1497,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3354,6 +3397,8 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3427,6 +3472,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4837,8 +4883,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
- "tungstenite",
+ "tokio-tungstenite 0.20.1",
+ "tungstenite 0.20.1",
  "url",
 ]
 
@@ -5992,6 +6038,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "storm-cex"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "rust_decimal",
+ "rustls 0.23.40",
+ "serde",
+ "serde_json",
+ "storm-core",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "storm-cli"
 version = "0.1.0"
 dependencies = [
@@ -6017,6 +6079,18 @@ dependencies = [
  "serde",
  "solana-sdk",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "storm-monitor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "storm-cex",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6322,8 +6396,24 @@ dependencies = [
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
- "tungstenite",
+ "tungstenite 0.20.1",
  "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -6556,6 +6646,26 @@ dependencies = [
  "url",
  "utf-8",
  "webpki-roots 0.24.0",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,17 @@ repository = "https://github.com/rgg81/solana-storm"
 storm-core = { path = "crates/storm-core" }
 storm-solana = { path = "crates/storm-solana" }
 storm-store = { path = "crates/storm-store" }
+storm-cex = { path = "crates/storm-cex" }
 
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = "0.7"
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
+futures-util = "0.3"
+rustls = "0.23"
 thiserror = "1"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 config = { version = "0.14", default-features = false, features = ["toml"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/bins/storm-monitor/Cargo.toml
+++ b/bins/storm-monitor/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "storm-monitor"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+storm-cex.workspace = true
+
+tokio.workspace = true
+tokio-util.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/bins/storm-monitor/src/main.rs
+++ b/bins/storm-monitor/src/main.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use storm_cex::{BinanceFeed, CexEvent, FeedConfig};
+use tokio::sync::broadcast::error::RecvError;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Required before any wss:// connection — see storm_cex docs.
+    storm_cex::install_crypto_provider();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let config = FeedConfig::default().with_env_overrides();
+    info!(
+        spot = %config.spot_ws_base,
+        futures = %config.futures_ws_base,
+        symbols = ?config.symbols,
+        "starting storm-monitor"
+    );
+
+    let feed = BinanceFeed::new(config);
+    let mut rx = feed.subscribe();
+    let cancel = CancellationToken::new();
+    let handles = feed.spawn(cancel.clone());
+
+    println!("storm-monitor — streaming Binance ticks (Ctrl-C to stop)");
+
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("\nshutdown signal received — closing streams…");
+                cancel.cancel();
+                break;
+            }
+            ev = rx.recv() => match ev {
+                Ok(CexEvent::Price(t)) => {
+                    println!(
+                        "[{:<15}] {:<5} bid {:>16} ask {:>16}  spread {:>7} bps",
+                        t.source, t.symbol, t.bid, t.ask, t.spread_bps().round_dp(2)
+                    );
+                }
+                Ok(CexEvent::Funding(f)) => {
+                    println!(
+                        "[funding        ] {:<5} mark {:>16} funding_rate {:>12}",
+                        f.symbol, f.mark_price, f.funding_rate
+                    );
+                }
+                Err(RecvError::Lagged(n)) => {
+                    warn!("consumer lagged — dropped {n} ticks");
+                }
+                Err(RecvError::Closed) => {
+                    warn!("feed channel closed — exiting");
+                    break;
+                }
+            }
+        }
+    }
+
+    // Graceful shutdown: give the stream tasks a moment to close cleanly.
+    for h in handles {
+        let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+    }
+    println!("storm-monitor stopped.");
+    Ok(())
+}

--- a/crates/storm-cex/Cargo.toml
+++ b/crates/storm-cex/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "storm-cex"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+storm-core.workspace = true
+
+tokio.workspace = true
+tokio-util.workspace = true
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+rust_decimal.workspace = true
+rustls.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/crates/storm-cex/src/feed.rs
+++ b/crates/storm-cex/src/feed.rs
@@ -1,0 +1,138 @@
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::types::{CexEvent, Source};
+use crate::ws::{run_stream, StreamKind};
+
+/// Default Binance spot WebSocket base (global venue).
+pub const DEFAULT_SPOT_WS: &str = "wss://stream.binance.com:9443";
+/// Default Binance USD-M futures WebSocket base (global venue).
+pub const DEFAULT_FUTURES_WS: &str = "wss://fstream.binance.com";
+
+#[derive(Debug, Clone)]
+pub struct FeedConfig {
+    /// Spot WS base URL, no path (e.g. `wss://stream.binance.com:9443`).
+    pub spot_ws_base: String,
+    /// USD-M futures WS base URL, no path (e.g. `wss://fstream.binance.com`).
+    pub futures_ws_base: String,
+    /// Binance symbols to subscribe (e.g. `["SOLUSDT", "ETHUSDT", "BTCUSDT"]`).
+    pub symbols: Vec<String>,
+    /// Broadcast channel capacity (ticks buffered for slow consumers).
+    pub channel_capacity: usize,
+}
+
+impl Default for FeedConfig {
+    fn default() -> Self {
+        Self {
+            spot_ws_base: DEFAULT_SPOT_WS.to_string(),
+            futures_ws_base: DEFAULT_FUTURES_WS.to_string(),
+            symbols: ["SOLUSDT", "ETHUSDT", "BTCUSDT"].map(String::from).to_vec(),
+            channel_capacity: 1024,
+        }
+    }
+}
+
+impl FeedConfig {
+    /// Override the WS base URLs from `BINANCE_SPOT_WS` / `BINANCE_FUTURES_WS`
+    /// if set — useful for Binance.US or a local mock server.
+    pub fn with_env_overrides(mut self) -> Self {
+        if let Ok(v) = std::env::var("BINANCE_SPOT_WS") {
+            self.spot_ws_base = v;
+        }
+        if let Ok(v) = std::env::var("BINANCE_FUTURES_WS") {
+            self.futures_ws_base = v;
+        }
+        self
+    }
+
+    fn combined_url(base: &str, suffix: &str, symbols: &[String]) -> String {
+        let streams = symbols
+            .iter()
+            .map(|s| format!("{}@{suffix}", s.to_lowercase()))
+            .collect::<Vec<_>>()
+            .join("/");
+        format!("{base}/stream?streams={streams}")
+    }
+
+    pub fn spot_book_ticker_url(&self) -> String {
+        Self::combined_url(&self.spot_ws_base, "bookTicker", &self.symbols)
+    }
+
+    pub fn futures_mark_price_url(&self) -> String {
+        Self::combined_url(&self.futures_ws_base, "markPrice", &self.symbols)
+    }
+}
+
+/// Owns the broadcast channel and spawns the Binance stream tasks.
+pub struct BinanceFeed {
+    config: FeedConfig,
+    tx: broadcast::Sender<CexEvent>,
+}
+
+impl BinanceFeed {
+    pub fn new(config: FeedConfig) -> Self {
+        let (tx, _) = broadcast::channel(config.channel_capacity);
+        Self { config, tx }
+    }
+
+    /// A new receiver. Subscribe *before* calling [`BinanceFeed::spawn`] to
+    /// avoid missing early ticks.
+    pub fn subscribe(&self) -> broadcast::Receiver<CexEvent> {
+        self.tx.subscribe()
+    }
+
+    pub fn config(&self) -> &FeedConfig {
+        &self.config
+    }
+
+    /// Spawn the spot `bookTicker` and futures `markPrice` stream tasks.
+    /// Each reconnects on its own until `cancel` fires.
+    pub fn spawn(&self, cancel: CancellationToken) -> Vec<JoinHandle<()>> {
+        vec![
+            tokio::spawn(run_stream(
+                self.config.spot_book_ticker_url(),
+                StreamKind::BookTicker(Source::BinanceSpot),
+                self.tx.clone(),
+                cancel.clone(),
+            )),
+            tokio::spawn(run_stream(
+                self.config.futures_mark_price_url(),
+                StreamKind::MarkPrice,
+                self.tx.clone(),
+                cancel,
+            )),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_combined_stream_urls() {
+        let cfg = FeedConfig {
+            spot_ws_base: "wss://spot".into(),
+            futures_ws_base: "wss://fut".into(),
+            symbols: vec!["SOLUSDT".into(), "ETHUSDT".into()],
+            channel_capacity: 16,
+        };
+        assert_eq!(
+            cfg.spot_book_ticker_url(),
+            "wss://spot/stream?streams=solusdt@bookTicker/ethusdt@bookTicker"
+        );
+        assert_eq!(
+            cfg.futures_mark_price_url(),
+            "wss://fut/stream?streams=solusdt@markPrice/ethusdt@markPrice"
+        );
+    }
+
+    #[test]
+    fn default_targets_binance_global() {
+        let cfg = FeedConfig::default();
+        assert!(cfg.spot_ws_base.contains("stream.binance.com"));
+        assert!(cfg.futures_ws_base.contains("fstream.binance.com"));
+        assert_eq!(cfg.symbols.len(), 3);
+    }
+}

--- a/crates/storm-cex/src/lib.rs
+++ b/crates/storm-cex/src/lib.rs
@@ -1,0 +1,18 @@
+pub mod feed;
+pub mod types;
+pub mod ws;
+
+pub use feed::{BinanceFeed, FeedConfig, DEFAULT_FUTURES_WS, DEFAULT_SPOT_WS};
+pub use types::{normalize_symbol, CexEvent, FundingTick, PriceTick, Source};
+pub use ws::{next_backoff, parse_book_ticker, parse_mark_price, run_stream, StreamKind};
+
+/// Install the process-wide rustls crypto provider.
+///
+/// Must be called once, early in `main()`, before opening any `wss://`
+/// connection. Without it rustls 0.23 panics at connect time: the
+/// dependency tree pulls in both the `ring` and `aws-lc-rs` backends
+/// (via tokio-tungstenite and reqwest respectively), so rustls cannot
+/// auto-select one. Idempotent — a second call is a no-op.
+pub fn install_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}

--- a/crates/storm-cex/src/types.rs
+++ b/crates/storm-cex/src/types.rs
@@ -1,0 +1,117 @@
+use std::fmt;
+
+use rust_decimal::Decimal;
+
+/// Which Binance venue a tick came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    BinanceSpot,
+    BinanceFutures,
+}
+
+impl Source {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Source::BinanceSpot => "binance-spot",
+            Source::BinanceFutures => "binance-futures",
+        }
+    }
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Best bid/ask snapshot for one symbol, normalised across venues.
+#[derive(Debug, Clone)]
+pub struct PriceTick {
+    /// Base asset, upper-cased (e.g. `SOL`). Quote is always USDT here.
+    pub symbol: String,
+    pub bid: Decimal,
+    pub ask: Decimal,
+    /// Milliseconds since the Unix epoch (local receive time).
+    pub timestamp: i64,
+    pub source: Source,
+}
+
+impl PriceTick {
+    pub fn mid(&self) -> Decimal {
+        (self.bid + self.ask) / Decimal::TWO
+    }
+
+    /// Bid/ask spread in basis points of the mid price.
+    pub fn spread_bps(&self) -> Decimal {
+        let mid = self.mid();
+        if mid.is_zero() {
+            return Decimal::ZERO;
+        }
+        (self.ask - self.bid) / mid * Decimal::from(10_000)
+    }
+}
+
+/// Perpetual-futures mark price + funding rate for one symbol.
+#[derive(Debug, Clone)]
+pub struct FundingTick {
+    pub symbol: String,
+    pub mark_price: Decimal,
+    /// Current funding rate (e.g. `0.0001` = 1 bp per funding interval).
+    pub funding_rate: Decimal,
+    /// Milliseconds since the Unix epoch of the next funding settlement.
+    pub next_funding_time: i64,
+    pub timestamp: i64,
+}
+
+/// Anything the CEX feed broadcasts to consumers.
+#[derive(Debug, Clone)]
+pub enum CexEvent {
+    Price(PriceTick),
+    Funding(FundingTick),
+}
+
+/// Strip a known quote suffix from a Binance symbol, upper-casing the base.
+/// `"SOLUSDT"` → `"SOL"`; unknown suffixes pass through upper-cased.
+pub fn normalize_symbol(raw: &str) -> String {
+    let up = raw.to_uppercase();
+    for quote in ["USDT", "USDC", "BUSD", "FDUSD"] {
+        if let Some(base) = up.strip_suffix(quote) {
+            if !base.is_empty() {
+                return base.to_string();
+            }
+        }
+    }
+    up
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn normalize_strips_usdt() {
+        assert_eq!(normalize_symbol("SOLUSDT"), "SOL");
+        assert_eq!(normalize_symbol("btcusdt"), "BTC");
+        assert_eq!(normalize_symbol("ETHUSDC"), "ETH");
+    }
+
+    #[test]
+    fn normalize_passes_unknown_through() {
+        assert_eq!(normalize_symbol("WEIRD"), "WEIRD");
+    }
+
+    #[test]
+    fn mid_and_spread() {
+        let t = PriceTick {
+            symbol: "SOL".into(),
+            bid: Decimal::from_str("99.90").unwrap(),
+            ask: Decimal::from_str("100.10").unwrap(),
+            timestamp: 0,
+            source: Source::BinanceSpot,
+        };
+        assert_eq!(t.mid(), Decimal::from(100));
+        // spread = 0.20 / 100 * 10000 = 20 bps
+        assert_eq!(t.spread_bps(), Decimal::from(20));
+    }
+}

--- a/crates/storm-cex/src/ws.rs
+++ b/crates/storm-cex/src/ws.rs
@@ -1,0 +1,230 @@
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use futures_util::{SinkExt, StreamExt};
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use tokio::sync::broadcast;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::types::{normalize_symbol, CexEvent, FundingTick, PriceTick, Source};
+use storm_core::{Result, StormError};
+
+/// Initial reconnect delay; doubles up to [`MAX_BACKOFF`] on each failure.
+pub const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+/// Reconnect delay ceiling.
+pub const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Next exponential-backoff delay, capped at [`MAX_BACKOFF`].
+pub fn next_backoff(current: Duration) -> Duration {
+    (current * 2).min(MAX_BACKOFF)
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+// ---- Binance combined-stream payloads -------------------------------------
+
+#[derive(Deserialize)]
+struct Combined<T> {
+    #[allow(dead_code)]
+    stream: String,
+    data: T,
+}
+
+#[derive(Deserialize)]
+struct BookTickerData {
+    s: String, // symbol, e.g. "SOLUSDT"
+    b: String, // best bid price
+    a: String, // best ask price
+}
+
+#[derive(Deserialize)]
+struct MarkPriceData {
+    s: String, // symbol
+    p: String, // mark price
+    r: String, // funding rate
+    #[serde(rename = "T")]
+    next_funding_time: i64,
+}
+
+/// Parse a Binance combined-stream `bookTicker` frame into a [`PriceTick`].
+pub fn parse_book_ticker(json: &str, source: Source) -> Result<PriceTick> {
+    let msg: Combined<BookTickerData> = serde_json::from_str(json)
+        .map_err(|e| StormError::Parse(format!("bookTicker frame: {e}")))?;
+    let bid = Decimal::from_str(&msg.data.b)
+        .map_err(|e| StormError::Parse(format!("bid '{}': {e}", msg.data.b)))?;
+    let ask = Decimal::from_str(&msg.data.a)
+        .map_err(|e| StormError::Parse(format!("ask '{}': {e}", msg.data.a)))?;
+    Ok(PriceTick {
+        symbol: normalize_symbol(&msg.data.s),
+        bid,
+        ask,
+        timestamp: now_ms(),
+        source,
+    })
+}
+
+/// Parse a Binance combined-stream `markPrice` frame into a [`FundingTick`].
+pub fn parse_mark_price(json: &str) -> Result<FundingTick> {
+    let msg: Combined<MarkPriceData> = serde_json::from_str(json)
+        .map_err(|e| StormError::Parse(format!("markPrice frame: {e}")))?;
+    let mark_price = Decimal::from_str(&msg.data.p)
+        .map_err(|e| StormError::Parse(format!("mark price '{}': {e}", msg.data.p)))?;
+    let funding_rate = Decimal::from_str(&msg.data.r)
+        .map_err(|e| StormError::Parse(format!("funding rate '{}': {e}", msg.data.r)))?;
+    Ok(FundingTick {
+        symbol: normalize_symbol(&msg.data.s),
+        mark_price,
+        funding_rate,
+        next_funding_time: msg.data.next_funding_time,
+        timestamp: now_ms(),
+    })
+}
+
+/// Kind of stream a connection carries — selects the right parser.
+#[derive(Debug, Clone, Copy)]
+pub enum StreamKind {
+    BookTicker(Source),
+    MarkPrice,
+}
+
+impl StreamKind {
+    fn parse(&self, json: &str) -> Result<CexEvent> {
+        match self {
+            StreamKind::BookTicker(src) => parse_book_ticker(json, *src).map(CexEvent::Price),
+            StreamKind::MarkPrice => parse_mark_price(json).map(CexEvent::Funding),
+        }
+    }
+}
+
+/// Connect to `url`, pump frames into `tx`, and reconnect with exponential
+/// backoff until `cancel` fires. Returns only on cancellation.
+pub async fn run_stream(
+    url: String,
+    kind: StreamKind,
+    tx: broadcast::Sender<CexEvent>,
+    cancel: CancellationToken,
+) {
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        if cancel.is_cancelled() {
+            break;
+        }
+        match connect_async(&url).await {
+            Ok((ws, _resp)) => {
+                info!(%url, "cex stream connected");
+                backoff = INITIAL_BACKOFF; // reset once the handshake succeeds
+                pump(ws, kind, &tx, &cancel).await;
+            }
+            Err(e) => warn!(%url, error = %e, "cex stream connect failed"),
+        }
+        if cancel.is_cancelled() {
+            break;
+        }
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = tokio::time::sleep(backoff) => {}
+        }
+        backoff = next_backoff(backoff);
+        warn!(%url, "reconnecting cex stream");
+    }
+    info!(%url, "cex stream stopped");
+}
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn pump(
+    mut ws: WsStream,
+    kind: StreamKind,
+    tx: &broadcast::Sender<CexEvent>,
+    cancel: &CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                let _ = ws.close(None).await;
+                break;
+            }
+            msg = ws.next() => match msg {
+                Some(Ok(Message::Text(txt))) => match kind.parse(txt.as_str()) {
+                    Ok(ev) => {
+                        // A send error just means no consumers are attached.
+                        let _ = tx.send(ev);
+                    }
+                    Err(e) => debug!(error = %e, "skipped unparseable cex frame"),
+                },
+                Some(Ok(Message::Ping(payload))) => {
+                    let _ = ws.send(Message::Pong(payload)).await;
+                }
+                Some(Ok(Message::Close(_))) | None => {
+                    warn!("cex stream closed by peer");
+                    break;
+                }
+                Some(Ok(_)) => {} // pong / binary — ignore
+                Some(Err(e)) => {
+                    warn!(error = %e, "cex stream read error");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_doubles_and_caps() {
+        let mut b = INITIAL_BACKOFF;
+        assert_eq!(b, Duration::from_secs(1));
+        b = next_backoff(b);
+        assert_eq!(b, Duration::from_secs(2));
+        b = next_backoff(b);
+        assert_eq!(b, Duration::from_secs(4));
+        // Run it well past the cap.
+        for _ in 0..20 {
+            b = next_backoff(b);
+        }
+        assert_eq!(b, MAX_BACKOFF);
+    }
+
+    #[test]
+    fn parses_real_spot_book_ticker_frame() {
+        let frame = r#"{"stream":"solusdt@bookTicker","data":{"u":400900217,"s":"SOLUSDT","b":"88.88000000","B":"0.13600000","a":"88.94000000","A":"22.49700000"}}"#;
+        let tick = parse_book_ticker(frame, Source::BinanceSpot).unwrap();
+        assert_eq!(tick.symbol, "SOL");
+        assert_eq!(tick.bid.to_string(), "88.88000000");
+        assert_eq!(tick.ask.to_string(), "88.94000000");
+        assert_eq!(tick.source, Source::BinanceSpot);
+    }
+
+    #[test]
+    fn parses_real_futures_mark_price_frame() {
+        let frame = r#"{"stream":"solusdt@markPrice","data":{"e":"markPriceUpdate","E":1562305380000,"s":"SOLUSDT","p":"88.91000000","i":"88.90000000","P":"88.92000000","r":"0.00010000","T":1562306400000}}"#;
+        let funding = parse_mark_price(frame).unwrap();
+        assert_eq!(funding.symbol, "SOL");
+        assert_eq!(funding.mark_price.to_string(), "88.91000000");
+        assert_eq!(funding.funding_rate.to_string(), "0.00010000");
+        assert_eq!(funding.next_funding_time, 1562306400000);
+    }
+
+    #[test]
+    fn rejects_malformed_frame() {
+        assert!(parse_book_ticker("not json", Source::BinanceSpot).is_err());
+        assert!(parse_book_ticker(
+            r#"{"stream":"x","data":{"s":"SOLUSDT","b":"abc","a":"1"}}"#,
+            Source::BinanceSpot
+        )
+        .is_err());
+    }
+}

--- a/crates/storm-cex/tests/mock_server.rs
+++ b/crates/storm-cex/tests/mock_server.rs
@@ -1,0 +1,104 @@
+//! End-to-end pipeline tests against a local mock WebSocket server.
+//! No external network — verifies connect → read → parse → broadcast → consume
+//! and the reconnect loop.
+
+use std::time::Duration;
+
+use futures_util::SinkExt;
+use storm_cex::{run_stream, CexEvent, Source, StreamKind};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
+
+const FRAME: &str = r#"{"stream":"solusdt@bookTicker","data":{"u":1,"s":"SOLUSDT","b":"100.10","B":"1","a":"100.20","A":"2"}}"#;
+
+#[tokio::test]
+async fn pipeline_delivers_a_parsed_tick_from_a_mock_server() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Mock server: accept one WS connection, send one frame, hold it open.
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        ws.send(Message::Text(FRAME.into())).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(10)).await;
+    });
+
+    let (tx, mut rx) = broadcast::channel(16);
+    let cancel = CancellationToken::new();
+    let url = format!("ws://{addr}/stream?streams=solusdt@bookTicker");
+    let client = tokio::spawn(run_stream(
+        url,
+        StreamKind::BookTicker(Source::BinanceSpot),
+        tx,
+        cancel.clone(),
+    ));
+
+    let ev = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for a tick")
+        .expect("broadcast channel closed");
+    match ev {
+        CexEvent::Price(t) => {
+            assert_eq!(t.symbol, "SOL");
+            assert_eq!(t.bid.to_string(), "100.10");
+            assert_eq!(t.ask.to_string(), "100.20");
+            assert_eq!(t.source, Source::BinanceSpot);
+        }
+        other => panic!("expected Price, got {other:?}"),
+    }
+
+    cancel.cancel();
+    let _ = client.await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn client_reconnects_after_the_server_drops_the_connection() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Mock server: accept connections in a loop; send one frame, then close.
+    let server = tokio::spawn(async move {
+        for _ in 0..3 {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            if let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await {
+                let _ = ws.send(Message::Text(FRAME.into())).await;
+                let _ = ws.close(None).await;
+            }
+        }
+    });
+
+    let (tx, mut rx) = broadcast::channel(16);
+    let cancel = CancellationToken::new();
+    let url = format!("ws://{addr}/stream?streams=solusdt@bookTicker");
+    let client = tokio::spawn(run_stream(
+        url,
+        StreamKind::BookTicker(Source::BinanceSpot),
+        tx,
+        cancel.clone(),
+    ));
+
+    // First tick — initial connection.
+    let first = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out on first tick")
+        .expect("channel closed");
+    assert!(matches!(first, CexEvent::Price(_)));
+
+    // Second tick — only possible if the client reconnected after the drop.
+    let second = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        .await
+        .expect("timed out waiting for a post-reconnect tick")
+        .expect("channel closed");
+    assert!(matches!(second, CexEvent::Price(_)));
+
+    cancel.cancel();
+    let _ = client.await;
+    server.abort();
+}


### PR DESCRIPTION
Closes #12. First week of Phase 2 — the bot starts *receiving* data instead of polling. No paid services (Binance market data is public).

## Summary

- **`storm-cex` crate (new)**:
  - `types.rs` — `Source`, `PriceTick { symbol, bid, ask, timestamp, source }` (with `mid()` / `spread_bps()`), `FundingTick { symbol, mark_price, funding_rate, next_funding_time, timestamp }`, and the `CexEvent` enum carried by the broadcast channel. `normalize_symbol` strips the quote suffix (`SOLUSDT` → `SOL`).
  - `ws.rs` — combined-stream frame parsers for `bookTicker` (spot) and `markPrice` (futures); `run_stream` connects via `tokio-tungstenite`, pumps `Text` frames into a `broadcast::Sender`, answers Pings, and reconnects with exponential backoff (`next_backoff`: 1s doubling to a 60s cap, reset on a successful handshake). Cancellation via `tokio-util::CancellationToken`.
  - `feed.rs` — `FeedConfig` (Binance.com defaults; `BINANCE_SPOT_WS` / `BINANCE_FUTURES_WS` env overrides for Binance.US or a local mock) and `BinanceFeed`, which owns the broadcast channel and spawns the two stream tasks.
  - `install_crypto_provider()` — installs the process-wide rustls crypto provider. **Required** before any `wss://` connection (see "Bug caught" below).
- **`bins/storm-monitor` (new)** — the daemon: subscribes to the feed, prints ticks, shuts down gracefully on Ctrl-C (`tokio::signal` + `CancellationToken`, then joins the stream tasks with a 5 s timeout).

## Bug caught by smoke-testing (not by CI)

`tokio-tungstenite` pulls rustls 0.23, which **panics at connect time** if it can't pick a crypto provider — and our dep tree has *both* `ring` (via tokio-tungstenite) and `aws-lc-rs` (via reqwest), so rustls refuses to auto-select. CI's mock-server tests use plaintext `ws://` and never hit TLS, so they stayed green while the live daemon panicked. Fix: `storm_cex::install_crypto_provider()` called first thing in `main()`. This is exactly the class of bug that unit tests can't catch — verified by actually running the binary.

## Tests — 43 total (was 32)

- **storm-cex unit (9)**: symbol normalisation, `mid`/`spread_bps` math, backoff doubling + cap, real Binance `bookTicker` + `markPrice` frame parsing, malformed-frame rejection, combined-URL construction, config defaults.
- **storm-cex integration (2, `tests/mock_server.rs`)**: a local mock WebSocket server drives the full **connect → read → parse → broadcast → consume** pipeline; a second test drops the connection server-side and asserts the client **reconnects** to receive another tick. No external network — fully verifiable in CI.

## Verified live

```
$ ./target/debug/storm-monitor          # then SIGINT
INFO storm_monitor: starting storm-monitor spot=wss://stream.binance.com:9443 …
storm-monitor — streaming Binance ticks (Ctrl-C to stop)
INFO storm_cex::ws: cex stream connected url=wss://fstream.binance.com/stream?streams=solusdt@markPrice/…
shutdown signal received — closing streams…
INFO storm_cex::ws: cex stream stopped url=wss://fstream.binance.com/…
storm-monitor stopped.
```

Daemon start → feed spawn → **real TLS WebSocket connect to `fstream.binance.com`** → graceful SIGINT shutdown — all verified. 

**Sandbox limitation (not a code issue)**: this CI/build environment is in a Binance-restricted region. The futures WS handshake is accepted but the data plane stays silent (no market frames), and the spot port `9443` is blocked by the egress proxy. Both are environment artifacts — analogous to the Week 1 TLS egress issue. The target deployment is a Hetzner VPS in Germany (issue #5), where Binance.com streams fully. The parse → broadcast → consume pipeline is fully exercised by the mock-server integration tests regardless.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` — 43/43
- [x] `storm-monitor` runs, connects over TLS to Binance, shuts down cleanly on SIGINT
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJRvUJgvYBuDZynfvcJYxX)_