### PR TITLE
Week 6 — Solana account streaming + CEX-DEX engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6082,11 +6082,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "storm-engine"
+version = "0.1.0"
+dependencies = [
+ "rust_decimal",
+ "solana-sdk",
+ "storm-cex",
+ "storm-core",
+ "storm-solana",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "storm-monitor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
+ "rust_decimal",
+ "solana-sdk",
  "storm-cex",
+ "storm-core",
+ "storm-engine",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6097,12 +6116,20 @@ dependencies = [
 name = "storm-solana"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
+ "futures-util",
  "reqwest",
  "rust_decimal",
+ "serde",
+ "serde_json",
  "solana-client",
  "solana-sdk",
  "spl-token",
  "storm-core",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ storm-core = { path = "crates/storm-core" }
 storm-solana = { path = "crates/storm-solana" }
 storm-store = { path = "crates/storm-store" }
 storm-cex = { path = "crates/storm-cex" }
+storm-engine = { path = "crates/storm-engine" }
 
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = "0.7"
@@ -33,6 +34,7 @@ solana-client = "2"
 solana-sdk = "2"
 spl-token = "8"
 rust_decimal = "1"
+base64 = "0.22"
 
 proptest = "1"
 

--- a/bins/storm-monitor/src/main.rs
+++ b/bins/storm-monitor/src/main.rs
@@ -1,27 +1,74 @@
+use std::str::FromStr;
 use std::time::Duration;
 
-use storm_cex::{BinanceFeed, CexEvent, FeedConfig};
+use clap::{Parser, Subcommand};
+use rust_decimal::Decimal;
+use solana_sdk::pubkey::Pubkey;
+use storm_cex::{normalize_symbol, BinanceFeed, CexEvent, FeedConfig, DEFAULT_SPOT_WS};
+use storm_core::Config;
+use storm_engine::{CexDexEngine, DislocationEvent, EngineConfig, EngineEvent, Venue};
 use tokio::sync::broadcast::error::RecvError;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
+
+#[derive(Parser)]
+#[command(
+    name = "storm-monitor",
+    about = "Solana Storm monitoring daemon",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Stream raw Binance bid/ask + funding ticks.
+    Binance,
+    /// CEX vs DEX dashboard: Binance spot vs an Orca Whirlpool, with
+    /// real-time dislocation alerts.
+    CexDex {
+        /// Orca Whirlpool address (default: SOL/USDC 0.05% tier).
+        #[arg(long, default_value = "7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm")]
+        whirlpool: String,
+        /// Binance spot symbol to compare against.
+        #[arg(long, default_value = "SOLUSDC")]
+        symbol: String,
+        /// Dislocation threshold in basis points (0.1% = 10 bps).
+        #[arg(long, default_value_t = 10)]
+        threshold_bps: u32,
+    },
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Required before any wss:// connection — see storm_cex docs.
     storm_cex::install_crypto_provider();
-
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 
+    match Cli::parse().command {
+        Command::Binance => run_binance().await,
+        Command::CexDex {
+            whirlpool,
+            symbol,
+            threshold_bps,
+        } => run_cex_dex(whirlpool, symbol, threshold_bps).await,
+    }
+}
+
+/// Week 5 behaviour: print the raw Binance tick stream.
+async fn run_binance() -> anyhow::Result<()> {
     let config = FeedConfig::default().with_env_overrides();
     info!(
         spot = %config.spot_ws_base,
         futures = %config.futures_ws_base,
         symbols = ?config.symbols,
-        "starting storm-monitor"
+        "storm-monitor: binance feed"
     );
 
     let feed = BinanceFeed::new(config);
@@ -29,7 +76,69 @@ async fn main() -> anyhow::Result<()> {
     let cancel = CancellationToken::new();
     let handles = feed.spawn(cancel.clone());
 
-    println!("storm-monitor — streaming Binance ticks (Ctrl-C to stop)");
+    println!("storm-monitor binance — streaming ticks (Ctrl-C to stop)");
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("\nshutdown signal received — closing streams…");
+                cancel.cancel();
+                break;
+            }
+            ev = rx.recv() => match ev {
+                Ok(CexEvent::Price(t)) => println!(
+                    "[{:<15}] {:<5} bid {:>16} ask {:>16}  spread {:>7} bps",
+                    t.source, t.symbol, t.bid, t.ask, t.spread_bps().round_dp(2)
+                ),
+                Ok(CexEvent::Funding(f)) => println!(
+                    "[funding        ] {:<5} mark {:>16} funding_rate {:>12}",
+                    f.symbol, f.mark_price, f.funding_rate
+                ),
+                Err(RecvError::Lagged(n)) => warn!("consumer lagged — dropped {n} ticks"),
+                Err(RecvError::Closed) => break,
+            }
+        }
+    }
+    for h in handles {
+        let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+    }
+    println!("storm-monitor stopped.");
+    Ok(())
+}
+
+/// Week 6 deliverable: the CEX vs DEX dislocation dashboard.
+async fn run_cex_dex(whirlpool: String, symbol: String, threshold_bps: u32) -> anyhow::Result<()> {
+    let cfg = Config::load()?;
+    let whirlpool = Pubkey::from_str(&whirlpool)
+        .map_err(|e| anyhow::anyhow!("invalid whirlpool '{whirlpool}': {e}"))?;
+    let spot_base =
+        std::env::var("BINANCE_SPOT_WS").unwrap_or_else(|_| DEFAULT_SPOT_WS.to_string());
+    let threshold = Decimal::from(threshold_bps);
+
+    let engine_config = EngineConfig {
+        solana: cfg.solana,
+        binance_spot_ws_base: spot_base,
+        binance_symbol: symbol.clone(),
+        base_symbol: normalize_symbol(&symbol),
+        whirlpool,
+        threshold_bps: threshold,
+        channel_capacity: 1024,
+    };
+
+    let engine = CexDexEngine::new(1024);
+    let mut rx = engine.subscribe();
+    let cancel = CancellationToken::new();
+    let engine_task = {
+        let cancel = cancel.clone();
+        tokio::spawn(async move { engine.run(engine_config, cancel).await })
+    };
+
+    println!(
+        "storm-monitor cex-dex — Binance {symbol} vs Orca {whirlpool}\n\
+         dislocation threshold {threshold_bps} bps (Ctrl-C to stop)"
+    );
+
+    let mut last_cex: Option<Decimal> = None;
+    let mut last_dex: Option<Decimal> = None;
 
     loop {
         tokio::select! {
@@ -39,33 +148,46 @@ async fn main() -> anyhow::Result<()> {
                 break;
             }
             ev = rx.recv() => match ev {
-                Ok(CexEvent::Price(t)) => {
-                    println!(
-                        "[{:<15}] {:<5} bid {:>16} ask {:>16}  spread {:>7} bps",
-                        t.source, t.symbol, t.bid, t.ask, t.spread_bps().round_dp(2)
-                    );
+                Ok(EngineEvent::Price(mp)) => {
+                    match mp.venue {
+                        Venue::BinanceSpot => last_cex = Some(mp.price),
+                        Venue::OrcaWhirlpool => last_dex = Some(mp.price),
+                    }
+                    let cex_s = last_cex
+                        .map(|c| c.round_dp(6).to_string())
+                        .unwrap_or_else(|| "—".to_string());
+                    let dex_s = last_dex
+                        .map(|d| d.round_dp(6).to_string())
+                        .unwrap_or_else(|| "—".to_string());
+                    let diff_s = match (last_cex, last_dex) {
+                        (Some(c), Some(d)) if !d.is_zero() => {
+                            let diff = (c - d) / d * Decimal::from(10_000);
+                            let flag = if diff.abs() >= threshold {
+                                "  <-- DISLOCATION"
+                            } else {
+                                ""
+                            };
+                            format!("  diff {:>8} bps{}", diff.round_dp(2), flag)
+                        }
+                        _ => String::new(),
+                    };
+                    println!("CEX {cex_s:>14}   DEX {dex_s:>14}{diff_s}");
                 }
-                Ok(CexEvent::Funding(f)) => {
-                    println!(
-                        "[funding        ] {:<5} mark {:>16} funding_rate {:>12}",
-                        f.symbol, f.mark_price, f.funding_rate
-                    );
-                }
-                Err(RecvError::Lagged(n)) => {
-                    warn!("consumer lagged — dropped {n} ticks");
-                }
-                Err(RecvError::Closed) => {
-                    warn!("feed channel closed — exiting");
-                    break;
-                }
+                Ok(EngineEvent::Dislocation(DislocationEvent::Opened(d))) => println!(
+                    ">>> DISLOCATION OPENED  {} bps — {} (CEX {}, DEX {})",
+                    d.diff_bps.round_dp(2), d.direction(),
+                    d.cex_price.round_dp(6), d.dex_price.round_dp(6)
+                ),
+                Ok(EngineEvent::Dislocation(DislocationEvent::Closed { peak_bps, duration_ms, .. })) => println!(
+                    "<<< dislocation CLOSED  after {:.1}s — peak {} bps",
+                    duration_ms as f64 / 1000.0, peak_bps.round_dp(2)
+                ),
+                Err(RecvError::Lagged(n)) => warn!("dashboard lagged — dropped {n} events"),
+                Err(RecvError::Closed) => break,
             }
         }
     }
-
-    // Graceful shutdown: give the stream tasks a moment to close cleanly.
-    for h in handles {
-        let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
-    }
+    let _ = tokio::time::timeout(Duration::from_secs(6), engine_task).await;
     println!("storm-monitor stopped.");
     Ok(())
 }

--- a/crates/storm-cex/src/lib.rs
+++ b/crates/storm-cex/src/lib.rs
@@ -4,7 +4,7 @@ pub mod ws;
 
 pub use feed::{BinanceFeed, FeedConfig, DEFAULT_FUTURES_WS, DEFAULT_SPOT_WS};
 pub use types::{normalize_symbol, CexEvent, FundingTick, PriceTick, Source};
-pub use ws::{next_backoff, parse_book_ticker, parse_mark_price, run_stream, StreamKind};
+pub use ws::{parse_book_ticker, parse_mark_price, run_stream, StreamKind};
 
 /// Install the process-wide rustls crypto provider.
 ///

--- a/crates/storm-cex/src/ws.rs
+++ b/crates/storm-cex/src/ws.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures_util::{SinkExt, StreamExt};
 use rust_decimal::Decimal;
@@ -11,17 +11,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::types::{normalize_symbol, CexEvent, FundingTick, PriceTick, Source};
+use storm_core::backoff::{next_backoff, INITIAL_BACKOFF};
 use storm_core::{Result, StormError};
-
-/// Initial reconnect delay; doubles up to [`MAX_BACKOFF`] on each failure.
-pub const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
-/// Reconnect delay ceiling.
-pub const MAX_BACKOFF: Duration = Duration::from_secs(60);
-
-/// Next exponential-backoff delay, capped at [`MAX_BACKOFF`].
-pub fn next_backoff(current: Duration) -> Duration {
-    (current * 2).min(MAX_BACKOFF)
-}
 
 fn now_ms() -> i64 {
     SystemTime::now()
@@ -182,21 +173,6 @@ async fn pump(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn backoff_doubles_and_caps() {
-        let mut b = INITIAL_BACKOFF;
-        assert_eq!(b, Duration::from_secs(1));
-        b = next_backoff(b);
-        assert_eq!(b, Duration::from_secs(2));
-        b = next_backoff(b);
-        assert_eq!(b, Duration::from_secs(4));
-        // Run it well past the cap.
-        for _ in 0..20 {
-            b = next_backoff(b);
-        }
-        assert_eq!(b, MAX_BACKOFF);
-    }
 
     #[test]
     fn parses_real_spot_book_ticker_frame() {

--- a/crates/storm-core/src/backoff.rs
+++ b/crates/storm-core/src/backoff.rs
@@ -1,0 +1,33 @@
+use std::time::Duration;
+
+/// Initial delay for an exponential-backoff reconnect loop.
+pub const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Ceiling for the reconnect delay.
+pub const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Next exponential-backoff delay: doubles `current`, capped at [`MAX_BACKOFF`].
+///
+/// Callers reset to [`INITIAL_BACKOFF`] once a connection succeeds.
+pub fn next_backoff(current: Duration) -> Duration {
+    (current * 2).min(MAX_BACKOFF)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doubles_then_caps() {
+        let mut b = INITIAL_BACKOFF;
+        assert_eq!(b, Duration::from_secs(1));
+        b = next_backoff(b);
+        assert_eq!(b, Duration::from_secs(2));
+        b = next_backoff(b);
+        assert_eq!(b, Duration::from_secs(4));
+        for _ in 0..20 {
+            b = next_backoff(b);
+        }
+        assert_eq!(b, MAX_BACKOFF);
+    }
+}

--- a/crates/storm-core/src/lib.rs
+++ b/crates/storm-core/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod backoff;
 pub mod config;
 pub mod error;
 pub mod math;
 pub mod types;
 
+pub use backoff::{next_backoff, INITIAL_BACKOFF, MAX_BACKOFF};
 pub use config::{Config, SolanaConfig};
 pub use error::{Result, StormError};
 pub use math::{cpmm_swap_output, spot_price};

--- a/crates/storm-engine/Cargo.toml
+++ b/crates/storm-engine/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "storm-monitor"
+name = "storm-engine"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
@@ -9,14 +9,11 @@ repository.workspace = true
 
 [dependencies]
 storm-core.workspace = true
+storm-solana.workspace = true
 storm-cex.workspace = true
-storm-engine.workspace = true
 
 solana-sdk.workspace = true
-clap.workspace = true
-rust_decimal.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-anyhow.workspace = true
+rust_decimal.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true

--- a/crates/storm-engine/src/cex_dex.rs
+++ b/crates/storm-engine/src/cex_dex.rs
@@ -1,0 +1,442 @@
+//! Real-time CEX vs DEX price comparison.
+//!
+//! Streams Binance spot bid/ask and an Orca Whirlpool's on-chain price into
+//! a single [`DislocationDetector`], emitting [`EngineEvent`]s when the two
+//! venues diverge past a configurable threshold.
+
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rust_decimal::Decimal;
+use solana_sdk::pubkey::Pubkey;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use storm_cex::{run_stream, CexEvent, FeedConfig, Source, StreamKind};
+use storm_core::{Result, SolanaConfig};
+use storm_solana::{
+    sqrt_price_x64_to_price, subscribe_accounts, AccountUpdate, DexPool, RpcContext, WhirlpoolState,
+};
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Where a price observation came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Venue {
+    BinanceSpot,
+    OrcaWhirlpool,
+}
+
+/// One normalised price observation: quote-per-base for a single pair.
+#[derive(Debug, Clone)]
+pub struct MarketPrice {
+    pub venue: Venue,
+    pub symbol: String,
+    pub price: Decimal,
+    pub timestamp: i64,
+}
+
+/// A CEX/DEX price divergence at the moment it crossed the threshold.
+#[derive(Debug, Clone)]
+pub struct Dislocation {
+    pub cex_price: Decimal,
+    pub dex_price: Decimal,
+    /// Signed: positive ⇒ CEX above DEX (the DEX is the cheap leg).
+    pub diff_bps: Decimal,
+    pub detected_at: i64,
+}
+
+impl Dislocation {
+    /// Which way to trade to capture the divergence.
+    pub fn direction(&self) -> &'static str {
+        if self.diff_bps > Decimal::ZERO {
+            "buy DEX, sell CEX"
+        } else if self.diff_bps < Decimal::ZERO {
+            "buy CEX, sell DEX"
+        } else {
+            "flat"
+        }
+    }
+}
+
+/// Lifecycle event for a divergence.
+#[derive(Debug, Clone)]
+pub enum DislocationEvent {
+    /// The spread crossed the threshold.
+    Opened(Dislocation),
+    /// The spread fell back under the threshold.
+    Closed {
+        peak_bps: Decimal,
+        duration_ms: i64,
+        at: i64,
+    },
+}
+
+struct OpenState {
+    since: i64,
+    peak_bps: Decimal,
+}
+
+/// Tracks the latest CEX and DEX prices for one pair and reports when their
+/// spread opens or closes relative to `threshold_bps`.
+pub struct DislocationDetector {
+    threshold_bps: Decimal,
+    last_cex: Option<Decimal>,
+    last_dex: Option<Decimal>,
+    open: Option<OpenState>,
+}
+
+impl DislocationDetector {
+    pub fn new(threshold_bps: Decimal) -> Self {
+        Self {
+            threshold_bps,
+            last_cex: None,
+            last_dex: None,
+            open: None,
+        }
+    }
+
+    /// Signed CEX-vs-DEX spread in basis points, or `None` until both sides
+    /// have reported at least once.
+    pub fn current_diff_bps(&self) -> Option<Decimal> {
+        match (self.last_cex, self.last_dex) {
+            (Some(cex), Some(dex)) if !dex.is_zero() => {
+                Some((cex - dex) / dex * Decimal::from(10_000))
+            }
+            _ => None,
+        }
+    }
+
+    /// Record a price; returns an event if a divergence opened or closed.
+    pub fn observe(&mut self, price: &MarketPrice) -> Option<DislocationEvent> {
+        match price.venue {
+            Venue::BinanceSpot => self.last_cex = Some(price.price),
+            Venue::OrcaWhirlpool => self.last_dex = Some(price.price),
+        }
+        let (cex, dex) = match (self.last_cex, self.last_dex) {
+            (Some(c), Some(d)) => (c, d),
+            _ => return None,
+        };
+        if dex.is_zero() {
+            return None;
+        }
+        let diff_bps = (cex - dex) / dex * Decimal::from(10_000);
+        let abs = diff_bps.abs();
+
+        match &mut self.open {
+            None if abs >= self.threshold_bps => {
+                self.open = Some(OpenState {
+                    since: price.timestamp,
+                    peak_bps: abs,
+                });
+                Some(DislocationEvent::Opened(Dislocation {
+                    cex_price: cex,
+                    dex_price: dex,
+                    diff_bps,
+                    detected_at: price.timestamp,
+                }))
+            }
+            None => None,
+            Some(state) => {
+                if abs > state.peak_bps {
+                    state.peak_bps = abs;
+                }
+                if abs < self.threshold_bps {
+                    let event = DislocationEvent::Closed {
+                        peak_bps: state.peak_bps,
+                        duration_ms: price.timestamp - state.since,
+                        at: price.timestamp,
+                    };
+                    self.open = None;
+                    Some(event)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+/// Anything the engine publishes to its consumers.
+#[derive(Debug, Clone)]
+pub enum EngineEvent {
+    Price(MarketPrice),
+    Dislocation(DislocationEvent),
+}
+
+/// Inputs for [`CexDexEngine::run`].
+#[derive(Debug, Clone)]
+pub struct EngineConfig {
+    /// RPC + WS URLs and commitment for the Solana side.
+    pub solana: SolanaConfig,
+    /// Binance spot WS base URL (e.g. `wss://stream.binance.com:9443`).
+    pub binance_spot_ws_base: String,
+    /// Binance symbol to stream (e.g. `SOLUSDC`).
+    pub binance_symbol: String,
+    /// Display label for the base asset (e.g. `SOL`).
+    pub base_symbol: String,
+    /// Orca Whirlpool address to watch.
+    pub whirlpool: Pubkey,
+    /// Spread threshold for opening a dislocation.
+    pub threshold_bps: Decimal,
+    /// Broadcast / stream channel capacity.
+    pub channel_capacity: usize,
+}
+
+/// Orchestrates the Binance and Solana streams through a shared detector.
+pub struct CexDexEngine {
+    events_tx: broadcast::Sender<EngineEvent>,
+}
+
+impl CexDexEngine {
+    pub fn new(channel_capacity: usize) -> Self {
+        let (events_tx, _) = broadcast::channel(channel_capacity);
+        Self { events_tx }
+    }
+
+    /// A receiver for engine events. Subscribe before calling [`run`].
+    pub fn subscribe(&self) -> broadcast::Receiver<EngineEvent> {
+        self.events_tx.subscribe()
+    }
+
+    /// Run until `cancel` fires: one whirlpool fetch for decimals + initial
+    /// price, then the Binance and Solana streams feed a shared detector.
+    pub async fn run(&self, config: EngineConfig, cancel: CancellationToken) -> Result<()> {
+        let rpc = RpcContext::from_config(&config.solana);
+        let pool = rpc.fetch_orca_whirlpool(&config.whirlpool).await?;
+        let (dec_a, dec_b) = (pool.token_a().decimals, pool.token_b().decimals);
+        info!(
+            whirlpool = %config.whirlpool,
+            decimals_a = dec_a,
+            decimals_b = dec_b,
+            initial_price = %pool.price(),
+            "cex-dex engine: whirlpool resolved"
+        );
+
+        // Shared between the CEX and DEX consumer tasks.
+        let detector = Arc::new(Mutex::new(DislocationDetector::new(config.threshold_bps)));
+
+        // Seed with the initial on-chain price.
+        publish(
+            &detector,
+            &self.events_tx,
+            MarketPrice {
+                venue: Venue::OrcaWhirlpool,
+                symbol: config.base_symbol.clone(),
+                price: pool.price(),
+                timestamp: now_ms(),
+            },
+        );
+
+        // Binance spot bookTicker stream.
+        let feed_cfg = FeedConfig {
+            spot_ws_base: config.binance_spot_ws_base.clone(),
+            futures_ws_base: String::new(),
+            symbols: vec![config.binance_symbol.clone()],
+            channel_capacity: config.channel_capacity,
+        };
+        let (cex_tx, cex_rx) = broadcast::channel::<CexEvent>(config.channel_capacity);
+        let cex_stream = tokio::spawn(run_stream(
+            feed_cfg.spot_book_ticker_url(),
+            StreamKind::BookTicker(Source::BinanceSpot),
+            cex_tx,
+            cancel.clone(),
+        ));
+
+        // Solana accountSubscribe stream for the whirlpool account.
+        let (acct_tx, acct_rx) = mpsc::channel::<AccountUpdate>(256);
+        let dex_stream = tokio::spawn(subscribe_accounts(
+            config.solana.ws_url.clone(),
+            vec![config.whirlpool],
+            config.solana.commitment.clone(),
+            acct_tx,
+            cancel.clone(),
+        ));
+
+        let cex_consumer = tokio::spawn(consume_cex(
+            cex_rx,
+            detector.clone(),
+            self.events_tx.clone(),
+        ));
+        let dex_consumer = tokio::spawn(consume_dex(
+            acct_rx,
+            detector,
+            self.events_tx.clone(),
+            config.whirlpool,
+            config.base_symbol.clone(),
+            dec_a,
+            dec_b,
+        ));
+
+        cancel.cancelled().await;
+        let _ = tokio::join!(cex_stream, dex_stream, cex_consumer, dex_consumer);
+        Ok(())
+    }
+}
+
+/// Observe a price through the shared detector, then publish the price plus
+/// any resulting dislocation event.
+fn publish(
+    detector: &Arc<Mutex<DislocationDetector>>,
+    events_tx: &broadcast::Sender<EngineEvent>,
+    price: MarketPrice,
+) {
+    let event = detector
+        .lock()
+        .expect("detector mutex poisoned")
+        .observe(&price);
+    let _ = events_tx.send(EngineEvent::Price(price));
+    if let Some(event) = event {
+        let _ = events_tx.send(EngineEvent::Dislocation(event));
+    }
+}
+
+async fn consume_cex(
+    mut rx: broadcast::Receiver<CexEvent>,
+    detector: Arc<Mutex<DislocationDetector>>,
+    events_tx: broadcast::Sender<EngineEvent>,
+) {
+    loop {
+        match rx.recv().await {
+            Ok(CexEvent::Price(tick)) => publish(
+                &detector,
+                &events_tx,
+                MarketPrice {
+                    venue: Venue::BinanceSpot,
+                    symbol: tick.symbol.clone(),
+                    price: tick.mid(),
+                    timestamp: tick.timestamp,
+                },
+            ),
+            Ok(CexEvent::Funding(_)) => {}
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!("cex-dex engine: cex consumer lagged, dropped {n}");
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+}
+
+async fn consume_dex(
+    mut rx: mpsc::Receiver<AccountUpdate>,
+    detector: Arc<Mutex<DislocationDetector>>,
+    events_tx: broadcast::Sender<EngineEvent>,
+    whirlpool: Pubkey,
+    symbol: String,
+    dec_a: u8,
+    dec_b: u8,
+) {
+    while let Some(update) = rx.recv().await {
+        if update.pubkey != whirlpool {
+            continue;
+        }
+        match WhirlpoolState::unpack(&update.data) {
+            Ok(state) => publish(
+                &detector,
+                &events_tx,
+                MarketPrice {
+                    venue: Venue::OrcaWhirlpool,
+                    symbol: symbol.clone(),
+                    price: sqrt_price_x64_to_price(state.sqrt_price_x64, dec_a, dec_b),
+                    timestamp: now_ms(),
+                },
+            ),
+            Err(e) => warn!(error = %e, "cex-dex engine: whirlpool unpack failed"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn cex(price: &str, ts: i64) -> MarketPrice {
+        MarketPrice {
+            venue: Venue::BinanceSpot,
+            symbol: "SOL".into(),
+            price: Decimal::from_str(price).unwrap(),
+            timestamp: ts,
+        }
+    }
+
+    fn dex(price: &str, ts: i64) -> MarketPrice {
+        MarketPrice {
+            venue: Venue::OrcaWhirlpool,
+            symbol: "SOL".into(),
+            price: Decimal::from_str(price).unwrap(),
+            timestamp: ts,
+        }
+    }
+
+    #[test]
+    fn no_event_until_both_sides_seen() {
+        let mut d = DislocationDetector::new(Decimal::from(10));
+        assert!(d.observe(&cex("100", 0)).is_none());
+        assert!(d.current_diff_bps().is_none());
+        // DEX equal to CEX → 0 bps, still no event.
+        assert!(d.observe(&dex("100", 1)).is_none());
+        assert_eq!(d.current_diff_bps(), Some(Decimal::ZERO));
+    }
+
+    #[test]
+    fn no_event_below_threshold() {
+        let mut d = DislocationDetector::new(Decimal::from(10));
+        d.observe(&cex("100.00", 0));
+        // 100 vs 99.95 → ~5 bps, under the 10 bps threshold.
+        assert!(d.observe(&dex("99.95", 1)).is_none());
+    }
+
+    #[test]
+    fn opens_then_closes_with_size_and_duration() {
+        let mut d = DislocationDetector::new(Decimal::from(10));
+        d.observe(&cex("100", 0));
+
+        // 100 vs 99 → ~101 bps → opens.
+        let opened = d.observe(&dex("99", 1000)).expect("should open");
+        match opened {
+            DislocationEvent::Opened(disl) => {
+                assert!(disl.diff_bps > Decimal::from(100));
+                assert_eq!(disl.direction(), "buy DEX, sell CEX");
+            }
+            other => panic!("expected Opened, got {other:?}"),
+        }
+
+        // Still dislocated (~50 bps) → no event, peak retained.
+        assert!(d.observe(&dex("99.5", 2000)).is_none());
+
+        // Back in line → closes with the recorded peak + duration.
+        let closed = d.observe(&dex("100", 4000)).expect("should close");
+        match closed {
+            DislocationEvent::Closed {
+                peak_bps,
+                duration_ms,
+                ..
+            } => {
+                assert!(peak_bps > Decimal::from(100));
+                assert_eq!(duration_ms, 4000 - 1000);
+            }
+            other => panic!("expected Closed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn direction_flips_when_dex_is_richer() {
+        let mut d = DislocationDetector::new(Decimal::from(10));
+        d.observe(&cex("99", 0));
+        let opened = d.observe(&dex("100", 1)).expect("should open");
+        match opened {
+            DislocationEvent::Opened(disl) => {
+                assert!(disl.diff_bps < Decimal::ZERO);
+                assert_eq!(disl.direction(), "buy CEX, sell DEX");
+            }
+            other => panic!("expected Opened, got {other:?}"),
+        }
+    }
+}

--- a/crates/storm-engine/src/lib.rs
+++ b/crates/storm-engine/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod cex_dex;
+
+pub use cex_dex::{
+    CexDexEngine, Dislocation, DislocationDetector, DislocationEvent, EngineConfig, EngineEvent,
+    MarketPrice, Venue,
+};

--- a/crates/storm-solana/Cargo.toml
+++ b/crates/storm-solana/Cargo.toml
@@ -13,6 +13,18 @@ solana-client.workspace = true
 solana-sdk.workspace = true
 spl-token.workspace = true
 rust_decimal.workspace = true
+
+tokio.workspace = true
+tokio-util.workspace = true
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+base64.workspace = true
+tracing.workspace = true
 # Listed only to layer the `rustls-tls-native-roots` feature onto the reqwest
 # instance solana-client builds. See the comment in the workspace Cargo.toml.
 reqwest.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/crates/storm-solana/src/lib.rs
+++ b/crates/storm-solana/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod accounts;
 pub mod pools;
 pub mod rpc;
+pub mod ws;
 
 pub use accounts::{MintInfo, PortfolioEntry, TokenAccountSnapshot};
 pub use pools::{
@@ -8,6 +9,7 @@ pub use pools::{
     ORCA_WHIRLPOOL_PROGRAM_ID, RAYDIUM_AMM_V4_PROGRAM_ID,
 };
 pub use rpc::{AccountSnapshot, RpcContext};
+pub use ws::{subscribe_accounts, AccountUpdate};
 
 // Feature-unification anchor: see workspace Cargo.toml.
 use reqwest as _;

--- a/crates/storm-solana/src/ws.rs
+++ b/crates/storm-solana/src/ws.rs
@@ -1,0 +1,259 @@
+//! Solana `accountSubscribe` WebSocket client.
+//!
+//! Opens a WebSocket to a Solana RPC node, subscribes to a fixed set of
+//! account addresses, and forwards every change notification as an
+//! [`AccountUpdate`]. Reconnects with exponential backoff.
+//!
+//! NOTE: a process-wide rustls `CryptoProvider` must be installed before
+//! the first `wss://` connection — see `storm_cex::install_crypto_provider`.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use base64::prelude::{Engine, BASE64_STANDARD};
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use solana_sdk::pubkey::Pubkey;
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use storm_core::backoff::{next_backoff, INITIAL_BACKOFF};
+use storm_core::{Result, StormError};
+
+/// A single account-change notification.
+#[derive(Debug, Clone)]
+pub struct AccountUpdate {
+    pub pubkey: Pubkey,
+    pub owner: Pubkey,
+    pub lamports: u64,
+    pub data: Vec<u8>,
+    pub slot: u64,
+}
+
+/// Subscribe to `accounts` over a Solana RPC WebSocket, forwarding every
+/// change to `tx`. Reconnects (and re-subscribes) with exponential backoff
+/// until `cancel` fires; returns only on cancellation or when `tx` closes.
+pub async fn subscribe_accounts(
+    ws_url: String,
+    accounts: Vec<Pubkey>,
+    commitment: String,
+    tx: mpsc::Sender<AccountUpdate>,
+    cancel: CancellationToken,
+) {
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        if cancel.is_cancelled() || tx.is_closed() {
+            break;
+        }
+        match connect_async(&ws_url).await {
+            Ok((ws, _resp)) => {
+                info!(%ws_url, accounts = accounts.len(), "solana account stream connected");
+                backoff = INITIAL_BACKOFF; // reset once the handshake succeeds
+                match run_subscription(ws, &accounts, &commitment, &tx, &cancel).await {
+                    Ok(()) => {}
+                    Err(e) => warn!(error = %e, "solana account stream ended"),
+                }
+            }
+            Err(e) => warn!(%ws_url, error = %e, "solana ws connect failed"),
+        }
+        if cancel.is_cancelled() || tx.is_closed() {
+            break;
+        }
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = tokio::time::sleep(backoff) => {}
+        }
+        backoff = next_backoff(backoff);
+        warn!(%ws_url, "reconnecting solana account stream");
+    }
+    info!(%ws_url, "solana account stream stopped");
+}
+
+fn subscribe_request(id: u64, pubkey: &Pubkey, commitment: &str) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "accountSubscribe",
+        "params": [
+            pubkey.to_string(),
+            { "encoding": "base64", "commitment": commitment }
+        ]
+    })
+    .to_string()
+}
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn run_subscription(
+    mut ws: WsStream,
+    accounts: &[Pubkey],
+    commitment: &str,
+    tx: &mpsc::Sender<AccountUpdate>,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    // Send one accountSubscribe per address; remember which request id maps
+    // to which pubkey so we can resolve subscription ids from confirmations.
+    let mut id_to_pubkey: HashMap<u64, Pubkey> = HashMap::with_capacity(accounts.len());
+    for (i, pk) in accounts.iter().enumerate() {
+        let id = (i as u64) + 1;
+        id_to_pubkey.insert(id, *pk);
+        ws.send(Message::Text(subscribe_request(id, pk, commitment)))
+            .await
+            .map_err(|e| StormError::Rpc(format!("accountSubscribe send: {e}")))?;
+    }
+
+    let mut sub_to_pubkey: HashMap<u64, Pubkey> = HashMap::with_capacity(accounts.len());
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                let _ = ws.close(None).await;
+                return Ok(());
+            }
+            msg = ws.next() => match msg {
+                Some(Ok(Message::Text(txt))) => {
+                    if let Some(update) =
+                        handle_message(txt.as_str(), &id_to_pubkey, &mut sub_to_pubkey)
+                    {
+                        if tx.send(update).await.is_err() {
+                            return Ok(()); // consumer dropped — stop
+                        }
+                    }
+                }
+                Some(Ok(Message::Ping(payload))) => {
+                    let _ = ws.send(Message::Pong(payload)).await;
+                }
+                Some(Ok(Message::Close(_))) | None => {
+                    warn!("solana ws closed by peer");
+                    return Ok(());
+                }
+                Some(Ok(_)) => {}
+                Some(Err(e)) => {
+                    return Err(StormError::Rpc(format!("solana ws read: {e}")));
+                }
+            }
+        }
+    }
+}
+
+// ---- message parsing ------------------------------------------------------
+
+#[derive(Deserialize)]
+struct NotificationParams {
+    subscription: u64,
+    result: NotificationResult,
+}
+
+#[derive(Deserialize)]
+struct NotificationResult {
+    context: NotificationContext,
+    value: AccountValue,
+}
+
+#[derive(Deserialize)]
+struct NotificationContext {
+    slot: u64,
+}
+
+#[derive(Deserialize)]
+struct AccountValue {
+    /// `[base64_payload, "base64"]` when `encoding: base64` is requested.
+    data: Vec<String>,
+    owner: String,
+    lamports: u64,
+}
+
+/// Dispatch one incoming text frame. Subscription confirmations populate
+/// `sub_to_pubkey`; account notifications produce an [`AccountUpdate`].
+fn handle_message(
+    text: &str,
+    id_to_pubkey: &HashMap<u64, Pubkey>,
+    sub_to_pubkey: &mut HashMap<u64, Pubkey>,
+) -> Option<AccountUpdate> {
+    let value: Value = serde_json::from_str(text).ok()?;
+
+    // Subscription confirmation: {"id": <req id>, "result": <sub id>}
+    if value.get("method").is_none() {
+        let req_id = value.get("id")?.as_u64()?;
+        let sub_id = value.get("result")?.as_u64()?;
+        if let Some(pk) = id_to_pubkey.get(&req_id) {
+            sub_to_pubkey.insert(sub_id, *pk);
+            debug!(req_id, sub_id, pubkey = %pk, "account subscription confirmed");
+        }
+        return None;
+    }
+
+    // Account change notification.
+    if value.get("method")?.as_str()? != "accountNotification" {
+        return None;
+    }
+    let params: NotificationParams = serde_json::from_value(value.get("params")?.clone()).ok()?;
+    let pubkey = *sub_to_pubkey.get(&params.subscription)?;
+    let b64 = params.result.value.data.first()?;
+    let data = BASE64_STANDARD.decode(b64).ok()?;
+    let owner = Pubkey::from_str(&params.result.value.owner).ok()?;
+    Some(AccountUpdate {
+        pubkey,
+        owner,
+        lamports: params.result.value.lamports,
+        data,
+        slot: params.result.context.slot,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscribe_request_shape() {
+        let pk = Pubkey::new_unique();
+        let req = subscribe_request(7, &pk, "confirmed");
+        let v: Value = serde_json::from_str(&req).unwrap();
+        assert_eq!(v["method"], "accountSubscribe");
+        assert_eq!(v["id"], 7);
+        assert_eq!(v["params"][0], pk.to_string());
+        assert_eq!(v["params"][1]["encoding"], "base64");
+        assert_eq!(v["params"][1]["commitment"], "confirmed");
+    }
+
+    #[test]
+    fn confirmation_then_notification_yields_an_update() {
+        let pk = Pubkey::new_unique();
+        let mut id_to_pubkey = HashMap::new();
+        id_to_pubkey.insert(1u64, pk);
+        let mut sub_to_pubkey = HashMap::new();
+
+        // Confirmation maps request id 1 -> subscription id 24.
+        let confirm = r#"{"jsonrpc":"2.0","result":24,"id":1}"#;
+        assert!(handle_message(confirm, &id_to_pubkey, &mut sub_to_pubkey).is_none());
+        assert_eq!(sub_to_pubkey.get(&24), Some(&pk));
+
+        // base64 of bytes [1, 2, 3] is "AQID".
+        let notif = r#"{"jsonrpc":"2.0","method":"accountNotification","params":{"result":{"context":{"slot":12345},"value":{"data":["AQID","base64"],"executable":false,"lamports":777,"owner":"11111111111111111111111111111111","rentEpoch":0,"space":3}},"subscription":24}}"#;
+        let update = handle_message(notif, &id_to_pubkey, &mut sub_to_pubkey).unwrap();
+        assert_eq!(update.pubkey, pk);
+        assert_eq!(update.data, vec![1, 2, 3]);
+        assert_eq!(update.lamports, 777);
+        assert_eq!(update.slot, 12345);
+    }
+
+    #[test]
+    fn notification_for_unknown_subscription_is_ignored() {
+        let id_to_pubkey = HashMap::new();
+        let mut sub_to_pubkey = HashMap::new();
+        let notif = r#"{"jsonrpc":"2.0","method":"accountNotification","params":{"result":{"context":{"slot":1},"value":{"data":["","base64"],"executable":false,"lamports":0,"owner":"11111111111111111111111111111111","rentEpoch":0,"space":0}},"subscription":999}}"#;
+        assert!(handle_message(notif, &id_to_pubkey, &mut sub_to_pubkey).is_none());
+    }
+
+    #[test]
+    fn garbage_frame_is_ignored() {
+        let id_to_pubkey = HashMap::new();
+        let mut sub_to_pubkey = HashMap::new();
+        assert!(handle_message("not json", &id_to_pubkey, &mut sub_to_pubkey).is_none());
+    }
+}

--- a/crates/storm-solana/tests/account_subscribe.rs
+++ b/crates/storm-solana/tests/account_subscribe.rs
@@ -1,0 +1,63 @@
+//! End-to-end test of the Solana `accountSubscribe` client against a local
+//! mock WebSocket server. No external network.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use solana_sdk::pubkey::Pubkey;
+use storm_solana::{subscribe_accounts, AccountUpdate};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn account_subscribe_pipeline_emits_an_update() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Mock RPC: accept the WS, read the subscribe request, confirm it, then
+    // push one account notification.
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        // Client sends exactly one accountSubscribe (request id 1).
+        let _req = ws.next().await;
+        ws.send(Message::Text(
+            r#"{"jsonrpc":"2.0","result":42,"id":1}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+        // base64 "AQID" decodes to bytes [1, 2, 3].
+        let notif = r#"{"jsonrpc":"2.0","method":"accountNotification","params":{"result":{"context":{"slot":100},"value":{"data":["AQID","base64"],"executable":false,"lamports":5,"owner":"11111111111111111111111111111111","rentEpoch":0,"space":3}},"subscription":42}}"#;
+        ws.send(Message::Text(notif.into())).await.unwrap();
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+    });
+
+    let account = Pubkey::new_unique();
+    let (tx, mut rx) = mpsc::channel::<AccountUpdate>(16);
+    let cancel = CancellationToken::new();
+    let client = tokio::spawn(subscribe_accounts(
+        format!("ws://{addr}"),
+        vec![account],
+        "confirmed".to_string(),
+        tx,
+        cancel.clone(),
+    ));
+
+    let update = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for an account update")
+        .expect("channel closed");
+    assert_eq!(update.pubkey, account);
+    assert_eq!(update.data, vec![1, 2, 3]);
+    assert_eq!(update.slot, 100);
+    assert_eq!(update.lamports, 5);
+
+    cancel.cancel();
+    let _ = client.await;
+    server.abort();
+}


### PR DESCRIPTION
Closes #13. The CEX and DEX feeds meet — real-time CEX-vs-DEX dislocation detection. No paid services (public Solana RPC + public Binance data).

## Summary

- **`storm-core/backoff.rs`** — extracted the exponential-backoff helper so `storm-cex` and `storm-solana` share one implementation.
- **`storm-solana/ws.rs`** — Solana `accountSubscribe` WebSocket client. `subscribe_accounts` connects, sends one `accountSubscribe` per address, resolves subscription ids from confirmations, base64-decodes each `accountNotification`, and forwards `AccountUpdate { pubkey, owner, lamports, data, slot }` over an mpsc channel. Reconnects + re-subscribes with exponential backoff.
- **`storm-engine` (new crate)** — `cex_dex.rs`:
  - `MarketPrice` / `Venue` — venue-normalised price observation.
  - `DislocationDetector` — holds the latest CEX + DEX price; emits `DislocationEvent::Opened` (size + direction) when the spread crosses the threshold and `::Closed` (peak + duration) when it resolves.
  - `CexDexEngine` — fetches the whirlpool once for decimals, then runs the Binance spot stream and the Solana `accountSubscribe` stream into a **shared `Arc<Mutex<DislocationDetector>>`**, publishing `EngineEvent` over a broadcast channel. Each whirlpool account update re-derives the price from `sqrt_price_x64`.
- **`storm-monitor`** — now a clap multi-command daemon: `binance` (Week 5 raw stream) and `cex-dex` (the Week 6 deliverable — Binance spot vs an Orca Whirlpool with live dislocation alerts).

## Tests — 52 total (was 43)

- `storm-engine` +4: detector open/close with size + duration, direction flip, sub-threshold no-op, two-sided gating.
- `storm-solana` +5 unit: `accountSubscribe` request shape, confirmation→notification dispatch, base64 decode, unknown-subscription + garbage-frame handling.
- `storm-solana` +1 integration (`tests/account_subscribe.rs`): a local mock RPC drives the full **subscribe → confirm → notify → AccountUpdate** pipeline. No external network.

## Verified live

```
$ storm-monitor cex-dex          # SIGINT after 70s
INFO cex-dex engine: whirlpool resolved whirlpool=7qbRF6Y… decimals_a=9 decimals_b=6 initial_price=88.96924841…
CEX              —   DEX      88.969248
INFO solana account stream connected ws_url=wss://api.mainnet-beta.solana.com accounts=1
CEX              —   DEX      88.974467
CEX              —   DEX      88.985230
CEX              —   DEX      89.008911
CEX              —   DEX      89.054380
CEX              —   DEX      89.034691      ← 11 live updates as swaps landed on-chain
storm-monitor stopped.
```

The Solana `accountSubscribe` WebSocket connected and streamed **11 real price updates over 70s** as swaps hit the Orca SOL/USDC 0.05% pool — live on-chain price tracking, end to end. Graceful SIGINT shutdown confirmed.

The `CEX` column stays empty because **Binance.com is geo-blocked from this sandbox region** (environment artifact — same as Week 5). The CEX→detector path is covered by the `storm-engine` unit tests and the Week 5 `storm-cex` mock-server integration test; the full subscribe→AccountUpdate path by the new `account_subscribe` integration test.

## Notes

- **Public RPC subscription behaviour**: the public Solana RPC *does* deliver `accountSubscribe` notifications, but is sparse on low-activity accounts — a quiet 0.3%-tier pool showed 0 updates in 24s while the busy 0.05% pool streamed freely. This is exactly the limitation Week 7's Yellowstone gRPC Geyser addresses.
- **Scope**: the live DEX feed is Orca Whirlpool (its pool account carries `sqrt_price`, updated in place on every swap — one subscription, self-contained). Raydium streaming (subscribe to the two vaults + cache static config) is the same `accountSubscribe` mechanism and composes naturally; deferred to the Phase 3 multi-DEX arb work.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` — 52/52
- [x] `storm-monitor cex-dex` streams live Orca prices over `accountSubscribe`; SIGINT shuts down cleanly
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJRvUJgvYBuDZynfvcJYxX)_